### PR TITLE
I had to do a double take to see that the "kanji"-field did not actually...

### DIFF
--- a/viewer.html
+++ b/viewer.html
@@ -58,7 +58,7 @@ title: Viewer
             <label class="control-label" for="kanji">Kanji</label>
 
             <div class="controls docs-input-sizes">
-                <input class="span3" type="text" value="" id="kanji" placeholder="線">
+                <input class="span3" type="text" value="" id="kanji" placeholder="e.g. 線">
             </div>
         </div>
 


### PR DESCRIPTION
... contain a Kanji, just a placeholder. I clicked on redraw several times without any effect until I noticed this. This change makes the placeholder more explicit.
