### PR TITLE
⻏ and 阝

### DIFF
--- a/kanji/02ecf.svg
+++ b/kanji/02ecf.svg
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (C) 2009/2010/2011 Ulrich Apel.
+This work is distributed under the conditions of the Creative Commons
+Attribution-Share Alike 3.0 Licence. This means you are free:
+* to Share - to copy, distribute and transmit the work
+* to Remix - to adapt the work
+
+Under the following conditions:
+* Attribution. You must attribute the work by stating your use of KanjiVG in
+  your own copyright header and linking to KanjiVG's website
+  (http://kanjivg.tagaini.net)
+* Share Alike. If you alter, transform, or build upon this work, you may
+  distribute the resulting work only under the same or similar license to this
+  one.
+
+See http://creativecommons.org/licenses/by-sa/3.0/ for more details.
+-->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.0//EN" "http://www.w3.org/TR/2001/REC-SVG-20010904/DTD/svg10.dtd" [
+<!ATTLIST g
+xmlns:kvg CDATA #FIXED "http://kanjivg.tagaini.net"
+kvg:element CDATA #IMPLIED
+kvg:variant CDATA #IMPLIED
+kvg:partial CDATA #IMPLIED
+kvg:original CDATA #IMPLIED
+kvg:part CDATA #IMPLIED
+kvg:number CDATA #IMPLIED
+kvg:tradForm CDATA #IMPLIED
+kvg:radicalForm CDATA #IMPLIED
+kvg:position CDATA #IMPLIED
+kvg:radical CDATA #IMPLIED
+kvg:phon CDATA #IMPLIED >
+<!ATTLIST path
+xmlns:kvg CDATA #FIXED "http://kanjivg.tagaini.net"
+kvg:type CDATA #IMPLIED >
+]>
+<svg xmlns="http://www.w3.org/2000/svg" width="109" height="109" viewBox="0 0 109 109">
+<g id="kvg:StrokePaths_02ecf" style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;">
+<g id="kvg:02ecf" kvg:element="⻏"  kvg:variant="true" kvg:original="邑" kvg:radical="tradit">
+	<path id="kvg:02ecf-s1" kvg:type="㇇" d="M 73.044237,13.54 c 1.56,0.28 3.41,0.8 5.34,0.48 9,-1.51 17.37,-3.14 20.62,-4.18 3.480003,-1.12 5.320003,1.83 3.900003,4.59 -2.03,3.95 -8.110003,15.24 -10.810003,19.08"/>
+	<path id="kvg:02ecf-s2" kvg:type="㇌" d="M 92.004237,33.75 c 16.000003,11 14.380003,37 -0.83,27.75"/>
+	<path id="kvg:02ecf-s3" kvg:type="㇑" d="M 74.874237,14.5 c 0.75,0.75 0.96,1.62 0.96,2.75 0,0.85 0.02,51.18 0.03,72.38 0,4.28 0,7.37 0,8.62"/>
+</g>
+</g>
+<g id="kvg:StrokeNumbers_02ecf" style="font-size:8;fill:#808080">
+	<text transform="matrix(1 0 0 1 67.50 11.25)">1</text>
+	<text transform="matrix(1 0 0 1 85.50 38.25)">2</text>
+	<text transform="matrix(1 0 0 1 68.50 23.25)">3</text>
+</g>
+</svg>

--- a/kanji/02ed6.svg
+++ b/kanji/02ed6.svg
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (C) 2009/2010/2011 Ulrich Apel.
+This work is distributed under the conditions of the Creative Commons
+Attribution-Share Alike 3.0 Licence. This means you are free:
+* to Share - to copy, distribute and transmit the work
+* to Remix - to adapt the work
+
+Under the following conditions:
+* Attribution. You must attribute the work by stating your use of KanjiVG in
+  your own copyright header and linking to KanjiVG's website
+  (http://kanjivg.tagaini.net)
+* Share Alike. If you alter, transform, or build upon this work, you may
+  distribute the resulting work only under the same or similar license to this
+  one.
+
+See http://creativecommons.org/licenses/by-sa/3.0/ for more details.
+-->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.0//EN" "http://www.w3.org/TR/2001/REC-SVG-20010904/DTD/svg10.dtd" [
+<!ATTLIST g
+xmlns:kvg CDATA #FIXED "http://kanjivg.tagaini.net"
+kvg:element CDATA #IMPLIED
+kvg:variant CDATA #IMPLIED
+kvg:partial CDATA #IMPLIED
+kvg:original CDATA #IMPLIED
+kvg:part CDATA #IMPLIED
+kvg:number CDATA #IMPLIED
+kvg:tradForm CDATA #IMPLIED
+kvg:radicalForm CDATA #IMPLIED
+kvg:position CDATA #IMPLIED
+kvg:radical CDATA #IMPLIED
+kvg:phon CDATA #IMPLIED >
+<!ATTLIST path
+xmlns:kvg CDATA #FIXED "http://kanjivg.tagaini.net"
+kvg:type CDATA #IMPLIED >
+]>
+<svg xmlns="http://www.w3.org/2000/svg" width="109" height="109" viewBox="0 0 109 109">
+<g id="kvg:StrokePaths_02ed6" style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;">
+<g id="kvg:02ed6" kvg:element="阝"  kvg:variant="true" kvg:original="阜" kvg:radical="tradit">
+	<path id="kvg:02ed6-s1" kvg:type="㇇" d="M 12.078136,13.54 c 1.56,0.28 3.41,0.8 5.34,0.48 9,-1.51 17.37,-3.14 20.62,-4.18 3.48,-1.12 5.32,1.83 3.9,4.59 -2.03,3.95 -8.11,15.24 -10.81,19.08"/>
+	<path id="kvg:02ed6-s2" kvg:type="㇌" d="M 31.038136,33.75 c 16,11 14.38,37 -0.83,27.75"/>
+	<path id="kvg:02ed6-s3" kvg:type="㇑" d="M 13.908136,14.5 c 0.75,0.75 0.96,1.62 0.96,2.75 0,0.85 0.02,51.18 0.03,72.38 0,4.28 0,7.37 0,8.62"/>
+</g>
+</g>
+<g id="kvg:StrokeNumbers_02ed6" style="font-size:8;fill:#808080">
+	<text transform="matrix(1 0 0 1 6.54 11.25)">1</text>
+	<text transform="matrix(1 0 0 1 24.54 38.25)">2</text>
+	<text transform="matrix(1 0 0 1 7.54 23.25)">3</text>
+</g>
+</svg>


### PR DESCRIPTION
Copy the shape from 0961d.svg to 02ecf.svg and 02ed6.svg, adding appropriate metadata.
Or as glyphs, 阝, ⻏, 阝.

This should fix half of the original #4, 2/3rds of it when you count my comment.

The central point is: should these be moved to the edges? For #92 the opinion was generally no, but here we have three code points, with 0961d centered, and the others with the “official” Unicode comments  “[form used on right side](http://www.fileformat.info/info/unicode/char/2ecf/index.htm)” and “[form used on left side](http://www.fileformat.info/info/unicode/char/2ed6/index.htm)”.
