### PR TITLE
use traditional form for kvg:0525d (fixes #110)

### DIFF
--- a/kanji/0525d.svg
+++ b/kanji/0525d.svg
@@ -36,7 +36,7 @@ kvg:type CDATA #IMPLIED >
 ]>
 <svg xmlns="http://www.w3.org/2000/svg" width="109" height="109" viewBox="0 0 109 109">
 <g id="kvg:StrokePaths_0525d" style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;">
-<g id="kvg:0525d" kvg:element="剥">
+<g id="kvg:0525d" kvg:element="剝">
 	<g id="kvg:0525d-g1" kvg:position="left">
 		<g id="kvg:0525d-g2" kvg:element="彑">
 			<path id="kvg:0525d-s1" kvg:type="㇗" d="M24.31,14c0.69,0.93,0.71,2.72,0.35,4.19c-1.73,6.98-2.61,9.47-4.78,14.8c-0.6,1.49-0.78,2.88,1.48,2.73c6.69-0.46,11.56-1.32,22.02-1.9"/>


### PR DESCRIPTION
KanjiVG has separate entries for 剝 (traditional, Joyo) and 剥 (simplification, commonly used); but both were using 剥 as the contents of kvg:element.