### PR TITLE
add namespace to unified xml file (fixes #111)

### DIFF
--- a/kvg.py
+++ b/kvg.py
@@ -75,7 +75,7 @@ def release():
 	out.write(licenseString)
 	out.write("\nThis file has been generated on %s, using the latest KanjiVG data\nto this date." % (datetime.date.today()))
 	out.write("\n-->\n")
-	out.write("<kanjivg>\n")
+	out.write("<kanjivg xmlns:kvg='http://kanjivg.tagaini.net'>\n")
 	for f in files:
 		data = open(os.path.join(datadir, f)).read()
 		data = data[data.find("<svg "):]


### PR DESCRIPTION
This helps with Pythons ElementTree, and possibly other strict parsers.