### PR TITLE
均: remove duplicate/spurious kvg:original

### DIFF
--- a/kanji/05747-Kaisho.svg
+++ b/kanji/05747-Kaisho.svg
@@ -49,7 +49,7 @@ kvg:type CDATA #IMPLIED >
 			</g>
 			<path id="kvg:05747-Kaisho-s5" kvg:type="㇆" d="M56.04,34.92c0.9,0.7,2.16,0.93,3.6,0.46c1.44-0.46,27.04-3.91,30.64-4.14c3.6-0.23,5.12,1.8,4.78,6.69C94.5,46,89.25,77.75,79.82,90.92c-2.7,3.76-3.63,1.74-5.76-1.16"/>
 		</g>
-		<g id="kvg:05747-Kaisho-g5" kvg:element="冫" kvg:original="二" kvg:original="氷" kvg:variant="true">
+		<g id="kvg:05747-Kaisho-g5" kvg:element="冫" kvg:original="二" kvg:variant="true">
 			<g id="kvg:05747-Kaisho-g6" kvg:element="二" kvg:variant="true">
 				<g id="kvg:05747-Kaisho-g7" kvg:position="top">
 					<path id="kvg:05747-Kaisho-s6" kvg:type="㇔" d="M55.77,46.33c4.07,1.66,10.52,6.81,11.54,9.38"/>


### PR DESCRIPTION
Very sorry.  I added a pre-commit hook calling `xmllint --valid` to my repo, so there should be no more validation errors introduced from it.