### PR TITLE
Swap 3/4 for 臼 and 6/7 for 潟

### DIFF
--- a/kanji/06f5f-HzFst.svg
+++ b/kanji/06f5f-HzFst.svg
@@ -35,45 +35,45 @@ xmlns:kvg CDATA #FIXED "http://kanjivg.tagaini.net"
 kvg:type CDATA #IMPLIED >
 ]>
 <svg xmlns="http://www.w3.org/2000/svg" width="109" height="109" viewBox="0 0 109 109">
-<g id="kvg:StrokePaths_06f5f-HzFst" style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;">
-<g id="kvg:06f5f-HzFst" kvg:element="潟">
-	<g id="kvg:06f5f-HzFst-g1" kvg:element="氵" kvg:variant="true" kvg:original="水" kvg:position="left" kvg:radical="general">
-		<path id="kvg:06f5f-HzFst-s1" kvg:type="㇔" d="M22.38,17.75c3.31,1.47,8.54,6.05,9.37,8.34"/>
-		<path id="kvg:06f5f-HzFst-s2" kvg:type="㇔" d="M14.75,40.25c3.79,1.54,9.8,6.35,10.75,8.75"/>
-		<path id="kvg:06f5f-HzFst-s3" kvg:type="㇀" d="M13.25,88.71c1.5,1.31,3.31,1.36,4.25-0.25C20.25,83.75,23,78,25.5,72"/>
+<g id="kvg:StrokePaths_06f5f" style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;">
+<g id="kvg:06f5f" kvg:element="潟">
+	<g id="kvg:06f5f-g1" kvg:element="氵" kvg:variant="true" kvg:original="水" kvg:position="left" kvg:radical="general">
+		<path id="kvg:06f5f-s1" kvg:type="㇔" d="M20.62,16.62c3.93,1.63,10.14,6.69,11.12,9.22"/>
+		<path id="kvg:06f5f-s2" kvg:type="㇔" d="M15,40.25c3.79,1.54,9.8,6.35,10.75,8.75"/>
+		<path id="kvg:06f5f-s3" kvg:type="㇀" d="M14.41,89.45c1.18,0.49,2.38,0.22,3.09-0.99C20.25,83.75,23,78,25.5,72"/>
 	</g>
-	<g id="kvg:06f5f-HzFst-g2" kvg:position="right">
-		<g id="kvg:06f5f-HzFst-g3" kvg:element="臼">
-			<path id="kvg:06f5f-HzFst-s4" kvg:type="㇒" d="M59.03,11.96c0.04,0.26,0.2,0.77-0.08,1.04c-2.95,2.75-6.25,5.98-14.4,8.91"/>
-			<path id="kvg:06f5f-HzFst-s5" kvg:type="㇑" d="M42.83,21.07c0.67,0.61,0.99,1.96,1.11,3.21c0.33,3.48,2.52,19.32,3.13,25.48"/>
-			<path id="kvg:06f5f-HzFst-s6" kvg:type="㇐" d="M46.49,34.38 c 0.79,0.14,1.42,0.42,2.53,0.42c1.11,0,12.48-1.36,13.75-1.49"/>
-			<path id="kvg:06f5f-HzFst-s7" kvg:type="㇕" d="M68.91,18.87c0.79,0.14,1.42,0.42,2.53,0.42c1.11,0,14.3-2.16,15.56-2.3c1.26-0.14,2.36,0.69,2.21,1.52c-1.46,8-5.46,22.5-7.82,29.73"/>
-			<path id="kvg:06f5f-HzFst-s8" kvg:type="㇐" d="M69.22,32.2c0.79,0.14,1.42,0.42,2.53,0.42c1.11,0,12.48-1.11,13.75-1.24"/>
-			<path id="kvg:06f5f-HzFst-s9" kvg:type="㇐" d="M47.23,47.4c2.05,0,31.16-1.8,33.53-1.94"/>
+	<g id="kvg:06f5f-g2" kvg:element="舄" kvg:position="right" kvg:phon="舄">
+		<g id="kvg:06f5f-g3" kvg:element="臼">
+			<path id="kvg:06f5f-s4" kvg:type="㇒" d="M58.78,11.71c0.13,0.79-0.22,1.69-0.77,2.19c-2.78,2.56-4.99,4.19-11.72,8.26"/>
+			<path id="kvg:06f5f-s5" kvg:type="㇑" d="M42.58,21.82c0.87,0.87,1.42,1.97,1.61,3.21c0.69,4.48,1.49,13.4,2.38,20.72c0.21,1.76,0.39,3.32,0.51,4.51"/>
+			<path id="kvg:06f5f-s6" kvg:type="㇕" d="M68.91,19.12c0.79,0.14,1.44,0.36,2.53,0.17c3.66-0.66,11.38-1.75,14.42-2.15c2.21-0.29,3.61,0.1,3.13,2.54c-1.25,6.33-3.77,15.84-5.89,23.02c-0.62,2.09-1.2,3.99-1.71,5.54"/>
+			<path id="kvg:06f5f-s7" kvg:type="㇐" d="M46.49,34.38 c 0.79,0.14,1.42,0.42,2.53,0.42c1.11,0,12.48-1.36,13.75-1.49"/>
+			<path id="kvg:06f5f-s8" kvg:type="㇐c" d="M68.72,32.2c0.79,0.14,1.42,0.42,2.53,0.42c1.11,0,12.48-1.36,13.75-1.49"/>
+			<path id="kvg:06f5f-s9" kvg:type="㇐a" d="M47.98,47.9c14.77-1.27,24.27-2.27,33.03-2.69"/>
 		</g>
-		<g id="kvg:06f5f-HzFst-g4" kvg:element="勹">
-			<g id="kvg:06f5f-HzFst-g5" kvg:element="丿">
-				<path id="kvg:06f5f-HzFst-s10" kvg:type="㇒" d="M52.03,51.5c0.06,0.51,0.12,1.31-0.11,2.03c-1.35,4.29-9.08,13.7-19.67,19.47"/>
+		<g id="kvg:06f5f-g4" kvg:element="勹">
+			<g id="kvg:06f5f-g5" kvg:element="丿">
+				<path id="kvg:06f5f-s10" kvg:type="㇒" d="M52.53,51.75c0.12,1.11-0.25,2.36-0.89,3.32c-3.39,5.06-9.77,12.06-19.39,18.18"/>
 			</g>
-			<path id="kvg:06f5f-HzFst-s11" kvg:type="㇆" d="M49.73,62.66c1,0.41,2.4,0.55,4.01,0.27c1.6-0.27,31.64-3.6,35.64-3.73c4-0.14,4.85,1.38,4.2,4.24c-2.33,10.32-6.08,21.32-11.62,30.12c-1.88,2.99-4.04,1.03-6.41-0.68"/>
+			<path id="kvg:06f5f-s11" kvg:type="㇆" d="M50.23,62.16c2.52,0.47,4.78,0.41,7.01,0.16c7.28-0.81,26.23-2.47,31.76-2.81c4.65-0.29,6.07,1.17,4.99,5.64c-2.2,9.13-5.54,17.68-10.28,26.97c-2.26,4.42-4.56,4.18-8.15,1"/>
 		</g>
-		<g id="kvg:06f5f-HzFst-g6" kvg:element="灬" kvg:variant="true" kvg:original="火">
-			<path id="kvg:06f5f-HzFst-s12" kvg:type="㇔" d="M35.71,77c0,4.71-0.6,11.65-0.75,13"/>
-			<path id="kvg:06f5f-HzFst-s13" kvg:type="㇔" d="M48,73.25c2.84,2.16,5.53,8.11,6.25,11.47"/>
-			<path id="kvg:06f5f-HzFst-s14" kvg:type="㇔" d="M60.75,71.25c2.05,1.71,5.31,7.05,5.82,9.72"/>
-			<path id="kvg:06f5f-HzFst-s15" kvg:type="㇔" d="M72,67.75c2.67,1.71,6.89,7.05,7.56,9.72"/>
+		<g id="kvg:06f5f-g6" kvg:element="灬" kvg:variant="true" kvg:original="火">
+			<path id="kvg:06f5f-s12" kvg:type="㇔" d="M35.85,77.38c0,3.15-0.35,9.5-1.29,12.12"/>
+			<path id="kvg:06f5f-s13" kvg:type="㇔" d="M48,73.5c2.73,2.11,5.31,7.93,6,11.22"/>
+			<path id="kvg:06f5f-s14" kvg:type="㇔" d="M60.38,70.62c2.28,1.83,5.88,7.5,6.45,10.34"/>
+			<path id="kvg:06f5f-s15" kvg:type="㇔" d="M72,68.25c2.58,1.58,6.66,6.51,7.31,8.97"/>
 		</g>
 	</g>
 </g>
 </g>
-<g id="kvg:StrokeNumbers_06f5f-HzFst" style="font-size:8;fill:#808080">
+<g id="kvg:StrokeNumbers_06f5f" style="font-size:8;fill:#808080">
 	<text transform="matrix(1 0 0 1 13.50 16.50)">1</text>
 	<text transform="matrix(1 0 0 1 7.50 40.50)">2</text>
 	<text transform="matrix(1 0 0 1 6.50 92.50)">3</text>
 	<text transform="matrix(1 0 0 1 50.50 11.50)">4</text>
 	<text transform="matrix(1 0 0 1 36.50 28.55)">5</text>
-	<text transform="matrix(1 0 0 1 49.50 31.50)">6</text>
-	<text transform="matrix(1 0 0 1 67.50 16.50)">7</text>
+	<text transform="matrix(1 0 0 1 67.50 16.50)">6</text>
+	<text transform="matrix(1 0 0 1 49.50 31.50)">7</text>
 	<text transform="matrix(1 0 0 1 68.25 29.50)">8</text>
 	<text transform="matrix(1 0 0 1 50.25 44.50)">9</text>
 	<text transform="matrix(1 0 0 1 38.50 58.63)">10</text>

--- a/kanji/06f5f.svg
+++ b/kanji/06f5f.svg
@@ -35,45 +35,45 @@ xmlns:kvg CDATA #FIXED "http://kanjivg.tagaini.net"
 kvg:type CDATA #IMPLIED >
 ]>
 <svg xmlns="http://www.w3.org/2000/svg" width="109" height="109" viewBox="0 0 109 109">
-<g id="kvg:StrokePaths_06f5f" style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;">
-<g id="kvg:06f5f" kvg:element="潟">
-	<g id="kvg:06f5f-g1" kvg:element="氵" kvg:variant="true" kvg:original="水" kvg:position="left" kvg:radical="general">
-		<path id="kvg:06f5f-s1" kvg:type="㇔" d="M20.62,16.62c3.93,1.63,10.14,6.69,11.12,9.22"/>
-		<path id="kvg:06f5f-s2" kvg:type="㇔" d="M15,40.25c3.79,1.54,9.8,6.35,10.75,8.75"/>
-		<path id="kvg:06f5f-s3" kvg:type="㇀" d="M14.41,89.45c1.18,0.49,2.38,0.22,3.09-0.99C20.25,83.75,23,78,25.5,72"/>
+<g id="kvg:StrokePaths_06f5f-HzFst" style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;">
+<g id="kvg:06f5f-HzFst" kvg:element="潟">
+	<g id="kvg:06f5f-HzFst-g1" kvg:element="氵" kvg:variant="true" kvg:original="水" kvg:position="left" kvg:radical="general">
+		<path id="kvg:06f5f-HzFst-s1" kvg:type="㇔" d="M22.38,17.75c3.31,1.47,8.54,6.05,9.37,8.34"/>
+		<path id="kvg:06f5f-HzFst-s2" kvg:type="㇔" d="M14.75,40.25c3.79,1.54,9.8,6.35,10.75,8.75"/>
+		<path id="kvg:06f5f-HzFst-s3" kvg:type="㇀" d="M13.25,88.71c1.5,1.31,3.31,1.36,4.25-0.25C20.25,83.75,23,78,25.5,72"/>
 	</g>
-	<g id="kvg:06f5f-g2" kvg:element="舄" kvg:position="right" kvg:phon="舄">
-		<g id="kvg:06f5f-g3" kvg:element="臼">
-			<path id="kvg:06f5f-s4" kvg:type="㇒" d="M58.78,11.71c0.13,0.79-0.22,1.69-0.77,2.19c-2.78,2.56-4.99,4.19-11.72,8.26"/>
-			<path id="kvg:06f5f-s5" kvg:type="㇑" d="M42.58,21.82c0.87,0.87,1.42,1.97,1.61,3.21c0.69,4.48,1.49,13.4,2.38,20.72c0.21,1.76,0.39,3.32,0.51,4.51"/>
-			<path id="kvg:06f5f-s6" kvg:type="㇕" d="M68.91,19.12c0.79,0.14,1.44,0.36,2.53,0.17c3.66-0.66,11.38-1.75,14.42-2.15c2.21-0.29,3.61,0.1,3.13,2.54c-1.25,6.33-3.77,15.84-5.89,23.02c-0.62,2.09-1.2,3.99-1.71,5.54"/>
-			<path id="kvg:06f5f-s7" kvg:type="㇐" d="M46.49,34.38 c 0.79,0.14,1.42,0.42,2.53,0.42c1.11,0,12.48-1.36,13.75-1.49"/>
-			<path id="kvg:06f5f-s8" kvg:type="㇐c" d="M68.72,32.2c0.79,0.14,1.42,0.42,2.53,0.42c1.11,0,12.48-1.36,13.75-1.49"/>
-			<path id="kvg:06f5f-s9" kvg:type="㇐a" d="M47.98,47.9c14.77-1.27,24.27-2.27,33.03-2.69"/>
+	<g id="kvg:06f5f-HzFst-g2" kvg:position="right">
+		<g id="kvg:06f5f-HzFst-g3" kvg:element="臼">
+			<path id="kvg:06f5f-HzFst-s4" kvg:type="㇒" d="M59.03,11.96c0.04,0.26,0.2,0.77-0.08,1.04c-2.95,2.75-6.25,5.98-14.4,8.91"/>
+			<path id="kvg:06f5f-HzFst-s5" kvg:type="㇑" d="M42.83,21.07c0.67,0.61,0.99,1.96,1.11,3.21c0.33,3.48,2.52,19.32,3.13,25.48"/>
+			<path id="kvg:06f5f-HzFst-s6" kvg:type="㇐" d="M46.49,34.38 c 0.79,0.14,1.42,0.42,2.53,0.42c1.11,0,12.48-1.36,13.75-1.49"/>
+			<path id="kvg:06f5f-HzFst-s7" kvg:type="㇕" d="M68.91,18.87c0.79,0.14,1.42,0.42,2.53,0.42c1.11,0,14.3-2.16,15.56-2.3c1.26-0.14,2.36,0.69,2.21,1.52c-1.46,8-5.46,22.5-7.82,29.73"/>
+			<path id="kvg:06f5f-HzFst-s8" kvg:type="㇐" d="M69.22,32.2c0.79,0.14,1.42,0.42,2.53,0.42c1.11,0,12.48-1.11,13.75-1.24"/>
+			<path id="kvg:06f5f-HzFst-s9" kvg:type="㇐" d="M47.23,47.4c2.05,0,31.16-1.8,33.53-1.94"/>
 		</g>
-		<g id="kvg:06f5f-g4" kvg:element="勹">
-			<g id="kvg:06f5f-g5" kvg:element="丿">
-				<path id="kvg:06f5f-s10" kvg:type="㇒" d="M52.53,51.75c0.12,1.11-0.25,2.36-0.89,3.32c-3.39,5.06-9.77,12.06-19.39,18.18"/>
+		<g id="kvg:06f5f-HzFst-g4" kvg:element="勹">
+			<g id="kvg:06f5f-HzFst-g5" kvg:element="丿">
+				<path id="kvg:06f5f-HzFst-s10" kvg:type="㇒" d="M52.03,51.5c0.06,0.51,0.12,1.31-0.11,2.03c-1.35,4.29-9.08,13.7-19.67,19.47"/>
 			</g>
-			<path id="kvg:06f5f-s11" kvg:type="㇆" d="M50.23,62.16c2.52,0.47,4.78,0.41,7.01,0.16c7.28-0.81,26.23-2.47,31.76-2.81c4.65-0.29,6.07,1.17,4.99,5.64c-2.2,9.13-5.54,17.68-10.28,26.97c-2.26,4.42-4.56,4.18-8.15,1"/>
+			<path id="kvg:06f5f-HzFst-s11" kvg:type="㇆" d="M49.73,62.66c1,0.41,2.4,0.55,4.01,0.27c1.6-0.27,31.64-3.6,35.64-3.73c4-0.14,4.85,1.38,4.2,4.24c-2.33,10.32-6.08,21.32-11.62,30.12c-1.88,2.99-4.04,1.03-6.41-0.68"/>
 		</g>
-		<g id="kvg:06f5f-g6" kvg:element="灬" kvg:variant="true" kvg:original="火">
-			<path id="kvg:06f5f-s12" kvg:type="㇔" d="M35.85,77.38c0,3.15-0.35,9.5-1.29,12.12"/>
-			<path id="kvg:06f5f-s13" kvg:type="㇔" d="M48,73.5c2.73,2.11,5.31,7.93,6,11.22"/>
-			<path id="kvg:06f5f-s14" kvg:type="㇔" d="M60.38,70.62c2.28,1.83,5.88,7.5,6.45,10.34"/>
-			<path id="kvg:06f5f-s15" kvg:type="㇔" d="M72,68.25c2.58,1.58,6.66,6.51,7.31,8.97"/>
+		<g id="kvg:06f5f-HzFst-g6" kvg:element="灬" kvg:variant="true" kvg:original="火">
+			<path id="kvg:06f5f-HzFst-s12" kvg:type="㇔" d="M35.71,77c0,4.71-0.6,11.65-0.75,13"/>
+			<path id="kvg:06f5f-HzFst-s13" kvg:type="㇔" d="M48,73.25c2.84,2.16,5.53,8.11,6.25,11.47"/>
+			<path id="kvg:06f5f-HzFst-s14" kvg:type="㇔" d="M60.75,71.25c2.05,1.71,5.31,7.05,5.82,9.72"/>
+			<path id="kvg:06f5f-HzFst-s15" kvg:type="㇔" d="M72,67.75c2.67,1.71,6.89,7.05,7.56,9.72"/>
 		</g>
 	</g>
 </g>
 </g>
-<g id="kvg:StrokeNumbers_06f5f" style="font-size:8;fill:#808080">
+<g id="kvg:StrokeNumbers_06f5f-HzFst" style="font-size:8;fill:#808080">
 	<text transform="matrix(1 0 0 1 13.50 16.50)">1</text>
 	<text transform="matrix(1 0 0 1 7.50 40.50)">2</text>
 	<text transform="matrix(1 0 0 1 6.50 92.50)">3</text>
 	<text transform="matrix(1 0 0 1 50.50 11.50)">4</text>
 	<text transform="matrix(1 0 0 1 36.50 28.55)">5</text>
-	<text transform="matrix(1 0 0 1 67.50 16.50)">6</text>
-	<text transform="matrix(1 0 0 1 49.50 31.50)">7</text>
+	<text transform="matrix(1 0 0 1 49.50 31.50)">6</text>
+	<text transform="matrix(1 0 0 1 67.50 16.50)">7</text>
 	<text transform="matrix(1 0 0 1 68.25 29.50)">8</text>
 	<text transform="matrix(1 0 0 1 50.25 44.50)">9</text>
 	<text transform="matrix(1 0 0 1 38.50 58.63)">10</text>

--- a/kanji/081fc-HzFst.svg
+++ b/kanji/081fc-HzFst.svg
@@ -35,21 +35,21 @@ xmlns:kvg CDATA #FIXED "http://kanjivg.tagaini.net"
 kvg:type CDATA #IMPLIED >
 ]>
 <svg xmlns="http://www.w3.org/2000/svg" width="109" height="109" viewBox="0 0 109 109">
-<g id="kvg:StrokePaths_081fc-HzFst" style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;">
-<g id="kvg:081fc-HzFst" kvg:element="臼" kvg:radical="general">
-	<path id="kvg:081fc-HzFst-s1" kvg:type="㇒" d="M47.55,17.46c0.07,0.47,0.29,1.37-0.14,1.87C41.75,26,35.15,31.95,22.25,37.25"/>
-	<path id="kvg:081fc-HzFst-s2" kvg:type="㇑" d="M19.53,35.73c1.06,1.1,1.5,3.55,1.76,5.8c0.96,8.22,3.99,40.35,4.96,51.47"/>
-	<path id="kvg:081fc-HzFst-s3" kvg:type="㇕" d="M23.75,60.25c5.25-0.5,19.75-2.5,21-2.5s3,0,4,0"/>
-	<path id="kvg:081fc-HzFst-s4" kvg:type="㇐" d="M60,31.75c1.25,0.25,2.25,0.75,4,0.75s20.25-3,22.25-3.25s3.66,1.24,3.5,2.75c-1.5,14.5-3.5,42.5-5,54.5c-0.22,1.74,0,2.75-0.25,3.75"/>
-	<path id="kvg:081fc-HzFst-s5" kvg:type="㇐" d="M60.5,56.75c1.25,0.25,2.25,0.75,4,0.75s19.75-2,21.75-2.25"/>
-	<path id="kvg:081fc-HzFst-s6" kvg:type="㇐" d="M26.5,88.75c3.25,0,53.25-3.25,57-3.5"/>
+<g id="kvg:StrokePaths_081fc" style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;">
+<g id="kvg:081fc" kvg:element="臼" kvg:radical="general">
+	<path id="kvg:081fc-s1" kvg:type="㇒" d="M48.55,18.21c-0.29,1.43-0.99,2.55-2.11,3.36c-6.01,5.4-12.97,10.31-23.94,15.67"/>
+	<path id="kvg:081fc-s2" kvg:type="㇑" d="M19.78,35.73c1.06,1.1,1.55,3.55,1.76,5.8c1.2,13.03,2.58,29.47,3.8,41.37c0.42,4.08,0.7,7.62,0.91,10.1"/>
+	<path id="kvg:081fc-s3" kvg:type="㇕" d="M60,31.75c2.17,0.67,4.34,0.85,6.52,0.53c4.85-0.52,14.99-1.82,18.6-2.37c3.51-0.54,4.76,0.46,4.47,4.21c-0.88,11.34-2.96,31.9-4.14,45.38c-0.42,4.83-0.76,8.68-0.95,10.75"/>
+	<path id="kvg:081fc-s4" kvg:type="㇐" d="M24.25,60.25c4.97-0.47,10.83-1.62,18.86-2.59c1.78-0.26,3.58-0.32,5.39-0.16"/>
+	<path id="kvg:081fc-s5" kvg:type="㇐" d="M60.5,57c2.17,0.49,4.34,0.59,6.51,0.31c5.46-0.5,17.62-1.86,19.24-2.06"/>
+	<path id="kvg:081fc-s6" kvg:type="㇐" d="M27,88.75c18.62-1.38,39.62-2.75,56.5-3.5"/>
 </g>
 </g>
-<g id="kvg:StrokeNumbers_081fc-HzFst" style="font-size:8;fill:#808080">
+<g id="kvg:StrokeNumbers_081fc" style="font-size:8;fill:#808080">
 	<text transform="matrix(1 0 0 1 40.50 17.50)">1</text>
 	<text transform="matrix(1 0 0 1 12.50 43.50)">2</text>
-	<text transform="matrix(1 0 0 1 29.25 56.50)">3</text>
-	<text transform="matrix(1 0 0 1 61.50 28.50)">4</text>
+	<text transform="matrix(1 0 0 1 61.50 28.50)">3</text>
+	<text transform="matrix(1 0 0 1 29.25 56.50)">4</text>
 	<text transform="matrix(1 0 0 1 59.50 53.50)">5</text>
 	<text transform="matrix(1 0 0 1 31.50 85.50)">6</text>
 </g>

--- a/kanji/081fc.svg
+++ b/kanji/081fc.svg
@@ -35,21 +35,21 @@ xmlns:kvg CDATA #FIXED "http://kanjivg.tagaini.net"
 kvg:type CDATA #IMPLIED >
 ]>
 <svg xmlns="http://www.w3.org/2000/svg" width="109" height="109" viewBox="0 0 109 109">
-<g id="kvg:StrokePaths_081fc" style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;">
-<g id="kvg:081fc" kvg:element="臼" kvg:radical="general">
-	<path id="kvg:081fc-s1" kvg:type="㇒" d="M48.55,18.21c-0.29,1.43-0.99,2.55-2.11,3.36c-6.01,5.4-12.97,10.31-23.94,15.67"/>
-	<path id="kvg:081fc-s2" kvg:type="㇑" d="M19.78,35.73c1.06,1.1,1.55,3.55,1.76,5.8c1.2,13.03,2.58,29.47,3.8,41.37c0.42,4.08,0.7,7.62,0.91,10.1"/>
-	<path id="kvg:081fc-s3" kvg:type="㇕" d="M60,31.75c2.17,0.67,4.34,0.85,6.52,0.53c4.85-0.52,14.99-1.82,18.6-2.37c3.51-0.54,4.76,0.46,4.47,4.21c-0.88,11.34-2.96,31.9-4.14,45.38c-0.42,4.83-0.76,8.68-0.95,10.75"/>
-	<path id="kvg:081fc-s4" kvg:type="㇐" d="M24.25,60.25c4.97-0.47,10.83-1.62,18.86-2.59c1.78-0.26,3.58-0.32,5.39-0.16"/>
-	<path id="kvg:081fc-s5" kvg:type="㇐" d="M60.5,57c2.17,0.49,4.34,0.59,6.51,0.31c5.46-0.5,17.62-1.86,19.24-2.06"/>
-	<path id="kvg:081fc-s6" kvg:type="㇐" d="M27,88.75c18.62-1.38,39.62-2.75,56.5-3.5"/>
+<g id="kvg:StrokePaths_081fc-HzFst" style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;">
+<g id="kvg:081fc-HzFst" kvg:element="臼" kvg:radical="general">
+	<path id="kvg:081fc-HzFst-s1" kvg:type="㇒" d="M47.55,17.46c0.07,0.47,0.29,1.37-0.14,1.87C41.75,26,35.15,31.95,22.25,37.25"/>
+	<path id="kvg:081fc-HzFst-s2" kvg:type="㇑" d="M19.53,35.73c1.06,1.1,1.5,3.55,1.76,5.8c0.96,8.22,3.99,40.35,4.96,51.47"/>
+	<path id="kvg:081fc-HzFst-s3" kvg:type="㇕" d="M23.75,60.25c5.25-0.5,19.75-2.5,21-2.5s3,0,4,0"/>
+	<path id="kvg:081fc-HzFst-s4" kvg:type="㇐" d="M60,31.75c1.25,0.25,2.25,0.75,4,0.75s20.25-3,22.25-3.25s3.66,1.24,3.5,2.75c-1.5,14.5-3.5,42.5-5,54.5c-0.22,1.74,0,2.75-0.25,3.75"/>
+	<path id="kvg:081fc-HzFst-s5" kvg:type="㇐" d="M60.5,56.75c1.25,0.25,2.25,0.75,4,0.75s19.75-2,21.75-2.25"/>
+	<path id="kvg:081fc-HzFst-s6" kvg:type="㇐" d="M26.5,88.75c3.25,0,53.25-3.25,57-3.5"/>
 </g>
 </g>
-<g id="kvg:StrokeNumbers_081fc" style="font-size:8;fill:#808080">
+<g id="kvg:StrokeNumbers_081fc-HzFst" style="font-size:8;fill:#808080">
 	<text transform="matrix(1 0 0 1 40.50 17.50)">1</text>
 	<text transform="matrix(1 0 0 1 12.50 43.50)">2</text>
-	<text transform="matrix(1 0 0 1 61.50 28.50)">3</text>
-	<text transform="matrix(1 0 0 1 29.25 56.50)">4</text>
+	<text transform="matrix(1 0 0 1 29.25 56.50)">3</text>
+	<text transform="matrix(1 0 0 1 61.50 28.50)">4</text>
 	<text transform="matrix(1 0 0 1 59.50 53.50)">5</text>
 	<text transform="matrix(1 0 0 1 31.50 85.50)">6</text>
 </g>


### PR DESCRIPTION
This changes the default for 臼 and 潟 to draw the left side first.

https://github.com/KanjiVG/kanjivg/issues/34 mentions that kakijun.jp has the current (outer strokes first) order as an allowed variant, but Kanjigen, Kangorin and http://www.amazon.co.jp/図解-毛筆書き方字典-阿保-直彦/dp/4839321442 all have the left side drawn first as the recommended order.
