### PR TITLE
Use correct character variants in certain kvg:element attributes

### DIFF
--- a/kanji/02ed6.svg
+++ b/kanji/02ed6.svg
@@ -36,7 +36,7 @@ kvg:type CDATA #IMPLIED >
 ]>
 <svg xmlns="http://www.w3.org/2000/svg" width="109" height="109" viewBox="0 0 109 109">
 <g id="kvg:StrokePaths_02ed6" style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;">
-<g id="kvg:02ed6" kvg:element="阝"  kvg:variant="true" kvg:original="阜" kvg:radical="tradit">
+<g id="kvg:02ed6" kvg:element="⻖"  kvg:variant="true" kvg:original="阜" kvg:radical="tradit">
 	<path id="kvg:02ed6-s1" kvg:type="㇇" d="M 12.078136,13.54 c 1.56,0.28 3.41,0.8 5.34,0.48 9,-1.51 17.37,-3.14 20.62,-4.18 3.48,-1.12 5.32,1.83 3.9,4.59 -2.03,3.95 -8.11,15.24 -10.81,19.08"/>
 	<path id="kvg:02ed6-s2" kvg:type="㇌" d="M 31.038136,33.75 c 16,11 14.38,37 -0.83,27.75"/>
 	<path id="kvg:02ed6-s3" kvg:type="㇑" d="M 13.908136,14.5 c 0.75,0.75 0.96,1.62 0.96,2.75 0,0.85 0.02,51.18 0.03,72.38 0,4.28 0,7.37 0,8.62"/>

--- a/kanji/0f92e.svg
+++ b/kanji/0f92e.svg
@@ -36,7 +36,7 @@ kvg:type CDATA #IMPLIED >
 ]>
 <svg xmlns="http://www.w3.org/2000/svg" width="109" height="109" viewBox="0 0 109 109">
 <g id="kvg:StrokePaths_0f92e" style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;">
-<g id="kvg:0f92e" kvg:element="冷">
+<g id="kvg:0f92e" kvg:element="冷">
 	<g id="kvg:0f92e-g1" kvg:element="冫" kvg:original="氷" kvg:position="left" kvg:radical="general">
 		<g id="kvg:0f92e-g2" kvg:position="top">
 			<path id="kvg:0f92e-s1" kvg:type="㇔" d="M13.88,24.62c3.99,1.97,10.31,8.11,11.31,11.18"/>
@@ -45,7 +45,7 @@ kvg:type CDATA #IMPLIED >
 			<path id="kvg:0f92e-s2" kvg:type="㇀" d="M12.6,84.79c1.46,0.67,3,0.19,3.94-1.07c1.21-1.62,8.56-14.38,13.21-22.6"/>
 		</g>
 	</g>
-	<g id="kvg:0f92e-g4" kvg:element="令" kvg:position="right" kvg:phon="令">
+	<g id="kvg:0f92e-g4" kvg:element="令" kvg:position="right" kvg:phon="令">
 		<g id="kvg:0f92e-g5" kvg:element="人" kvg:position="top">
 			<path id="kvg:0f92e-s3" kvg:type="㇒" d="M61.04,12.25c0.08,0.98,0.12,2.59-0.4,3.93C56.5,26.88,48,41.5,34.5,54.35"/>
 			<path id="kvg:0f92e-s4" kvg:type="㇏" d="M60.85,16.24c5.4,5.39,20.25,21.5,27.55,28.74c2.1,2.08,4.13,4.02,6.85,5.24"/>

--- a/kanji/0f9a8.svg
+++ b/kanji/0f9a8.svg
@@ -36,7 +36,7 @@ kvg:type CDATA #IMPLIED >
 ]>
 <svg xmlns="http://www.w3.org/2000/svg" width="109" height="109" viewBox="0 0 109 109">
 <g id="kvg:StrokePaths_0f9a8" style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;">
-<g id="kvg:0f9a8" kvg:element="令">
+<g id="kvg:0f9a8" kvg:element="令">
 	<g id="kvg:0f9a8-g1" kvg:element="人" kvg:position="top" kvg:radical="general">
 		<path id="kvg:0f9a8-s1" kvg:type="㇒" d="M49.62,13.25c0.11,0.94,0.38,2.48-0.22,3.77c-4.15,8.86-15.15,25.23-36.65,37.08"/>
 		<path id="kvg:0f9a8-s2" kvg:type="㇏" d="M50.54,16.55c6.13,4.35,24.99,20.22,33.98,27.33c3.22,2.54,5.6,4.12,9.73,5.37"/>

--- a/kanji/0f9ab.svg
+++ b/kanji/0f9ab.svg
@@ -36,14 +36,14 @@ kvg:type CDATA #IMPLIED >
 ]>
 <svg xmlns="http://www.w3.org/2000/svg" width="109" height="109" viewBox="0 0 109 109">
 <g id="kvg:StrokePaths_0f9ab" style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;">
-<g id="kvg:0f9ab" kvg:element="嶺">
+<g id="kvg:0f9ab" kvg:element="嶺">
 	<g id="kvg:0f9ab-g1" kvg:element="山" kvg:position="top" kvg:radical="general">
 		<path id="kvg:0f9ab-s1" kvg:type="㇑a" d="M53.26,9.38c0.99,0.99,1.12,2.09,1.12,3.12c0,0.67,0.06,8.38,0.06,13.01"/>
 		<path id="kvg:0f9ab-s2" kvg:type="㇄a" d="M26.18,16.75c0.7,1.25,0.79,2.26,0.62,3.41c-0.3,1.97-0.3,2.72-1.34,7.26c-0.34,1.49,0.04,2.56,2.11,2.28c17.56-2.45,35.93-3.95,52.85-4.55"/>
 		<path id="kvg:0f9ab-s3" kvg:type="㇑" d="M82.02,12.38c0.6,1.12,0.71,2.48,0.62,3.15c-0.56,4.07-0.77,5.98-1.54,11.69"/>
 	</g>
-	<g id="kvg:0f9ab-g2" kvg:element="領" kvg:position="bottom">
-		<g id="kvg:0f9ab-g3" kvg:element="令" kvg:position="left">
+	<g id="kvg:0f9ab-g2" kvg:element="領" kvg:position="bottom">
+		<g id="kvg:0f9ab-g3" kvg:element="令" kvg:position="left">
 			<g id="kvg:0f9ab-g4" kvg:element="人" kvg:position="top">
 				<path id="kvg:0f9ab-s4" kvg:type="㇒" d="M32.5,35.32c0.13,1.47-0.11,2.71-0.65,4.1c-2.08,5.36-8.21,13.8-18.33,22.63"/>
 				<path id="kvg:0f9ab-s5" kvg:type="㇔/㇏" d="M35.5,40.03c5,2.22,10.56,6.25,13.42,10.62"/>

--- a/kanji/0f9ad.svg
+++ b/kanji/0f9ad.svg
@@ -35,32 +35,32 @@ xmlns:kvg CDATA #FIXED "http://kanjivg.tagaini.net"
 kvg:type CDATA #IMPLIED >
 ]>
 <svg xmlns="http://www.w3.org/2000/svg" width="109" height="109" viewBox="0 0 109 109">
-<g id="kvg:StrokePaths_0f9ab" style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;">
-<g id="kvg:0f9ab" kvg:element="玲">
-	<g id="kvg:0f9ab-g1" kvg:element="王" kvg:original="玉" kvg:partial="true" kvg:position="left" kvg:radical="general">
-		<path id="kvg:0f9ab-s1" kvg:type="㇐" d="M9.65,28.33c1.53,0.84,5.07,0.34,6.71,0.11c4.56-0.63,10.35-1.83,15.79-2.75c1.41-0.24,3.32-0.74,4.74-0.23"/>
-		<path id="kvg:0f9ab-s2" kvg:type="㇑a" d="M22.42,30.71c1.06,1.06,1.31,2.04,1.31,3.38c0,4.92,0.04,35.9-0.11,39.17"/>
-		<path id="kvg:0f9ab-s3" kvg:type="㇐" d="M10.16,51.37c0.49,0.33,3.93,0.35,4.43,0.31C19,51.25,27.5,49.62,32.44,48.7c0.6-0.11,1.93-0.32,3.25-0.09"/>
-		<path id="kvg:0f9ab-s4" kvg:type="㇐" d="M10.77,78.95c1.03,0.83,2.01,1.11,3.51,0.33c5.6-2.9,10.93-6,18-9.92"/>
+<g id="kvg:StrokePaths_0f9ad" style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;">
+<g id="kvg:0f9ad" kvg:element="玲">
+	<g id="kvg:0f9ad-g1" kvg:element="王" kvg:original="玉" kvg:partial="true" kvg:position="left" kvg:radical="general">
+		<path id="kvg:0f9ad-s1" kvg:type="㇐" d="M9.65,28.33c1.53,0.84,5.07,0.34,6.71,0.11c4.56-0.63,10.35-1.83,15.79-2.75c1.41-0.24,3.32-0.74,4.74-0.23"/>
+		<path id="kvg:0f9ad-s2" kvg:type="㇑a" d="M22.42,30.71c1.06,1.06,1.31,2.04,1.31,3.38c0,4.92,0.04,35.9-0.11,39.17"/>
+		<path id="kvg:0f9ad-s3" kvg:type="㇐" d="M10.16,51.37c0.49,0.33,3.93,0.35,4.43,0.31C19,51.25,27.5,49.62,32.44,48.7c0.6-0.11,1.93-0.32,3.25-0.09"/>
+		<path id="kvg:0f9ad-s4" kvg:type="㇐" d="M10.77,78.95c1.03,0.83,2.01,1.11,3.51,0.33c5.6-2.9,10.93-6,18-9.92"/>
 	</g>
-	<g id="kvg:0f9ab-g2" kvg:element="令" kvg:position="right">
-		<g id="kvg:0f9ab-g3" kvg:element="人" kvg:position="top">
-			<path id="kvg:0f9ab-s5" kvg:type="㇒" d="M62.64,12.75c0.08,0.95,0.13,2.52-0.4,3.83C58.5,25.88,50.38,41.12,39,52.35"/>
-			<path id="kvg:0f9ab-s6" kvg:type="㇏" d="M62.92,17.79c8.4,8.61,15.21,17.33,24.47,26.71c2.09,2.12,5.1,4.24,7.37,5.63"/>
+	<g id="kvg:0f9ad-g2" kvg:element="令" kvg:position="right">
+		<g id="kvg:0f9ad-g3" kvg:element="人" kvg:position="top">
+			<path id="kvg:0f9ad-s5" kvg:type="㇒" d="M62.64,12.75c0.08,0.95,0.13,2.52-0.4,3.83C58.5,25.88,50.38,41.12,39,52.35"/>
+			<path id="kvg:0f9ad-s6" kvg:type="㇏" d="M62.92,17.79c8.4,8.61,15.21,17.33,24.47,26.71c2.09,2.12,5.1,4.24,7.37,5.63"/>
 		</g>
-		<g id="kvg:0f9ab-g4" kvg:position="bottom">
-			<g id="kvg:0f9ab-g5" kvg:element="一">
-				<path id="kvg:0f9ab-s7" kvg:type="㇐" d="M50.9,46.1c1.76,0.72,3.84,0.36,5.65,0.14c5.4-0.66,13.08-1.76,18.48-2.24c1.88-0.17,3.54-0.23,5.37,0.21"/>
+		<g id="kvg:0f9ad-g4" kvg:position="bottom">
+			<g id="kvg:0f9ad-g5" kvg:element="一">
+				<path id="kvg:0f9ad-s7" kvg:type="㇐" d="M50.9,46.1c1.76,0.72,3.84,0.36,5.65,0.14c5.4-0.66,13.08-1.76,18.48-2.24c1.88-0.17,3.54-0.23,5.37,0.21"/>
 			</g>
-			<g id="kvg:0f9ab-g6" kvg:element="卩" kvg:original="マ">
-				<path id="kvg:0f9ab-s8" kvg:type="㇆" d="M51.4,54.6c0.61,0.15,3,1,4.21,0.87c3.29-0.37,17.99-4.02,19.51-4.17c1.52-0.15,4.28-0.29,3.95,2.89c-0.43,4.17-2.68,16.92-6,23.84c-1.89,3.94-3.18,3.45-6.23,0.46"/>
-				<path id="kvg:0f9ab-s9" kvg:type="㇑" d="M58.58125,55.567708 c 0.87,0.87 1.8,2 1.8,3.5 -0.219826,13.545146 0.202719,23.466557 -0.18,37.006667"/>
+			<g id="kvg:0f9ad-g6" kvg:element="卩" kvg:original="マ">
+				<path id="kvg:0f9ad-s8" kvg:type="㇆" d="M51.4,54.6c0.61,0.15,3,1,4.21,0.87c3.29-0.37,17.99-4.02,19.51-4.17c1.52-0.15,4.28-0.29,3.95,2.89c-0.43,4.17-2.68,16.92-6,23.84c-1.89,3.94-3.18,3.45-6.23,0.46"/>
+				<path id="kvg:0f9ad-s9" kvg:type="㇑" d="M58.58125,55.567708 c 0.87,0.87 1.8,2 1.8,3.5 -0.219826,13.545146 0.202719,23.466557 -0.18,37.006667"/>
 			</g>
 		</g>
 	</g>
 </g>
 </g>
-<g id="kvg:StrokeNumbers_0f9ab" style="font-size:8;fill:#808080">
+<g id="kvg:StrokeNumbers_0f9ad" style="font-size:8;fill:#808080">
 	<text transform="matrix(1 0 0 1 3.60 28.25)">1</text>
 	<text transform="matrix(1 0 0 1 15.25 39.25)">2</text>
 	<text transform="matrix(1 0 0 1 3.25 52.25)">3</text>

--- a/kanji/0f9ad.svg
+++ b/kanji/0f9ad.svg
@@ -36,14 +36,14 @@ kvg:type CDATA #IMPLIED >
 ]>
 <svg xmlns="http://www.w3.org/2000/svg" width="109" height="109" viewBox="0 0 109 109">
 <g id="kvg:StrokePaths_0f9ad" style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;">
-<g id="kvg:0f9ad" kvg:element="玲">
+<g id="kvg:0f9ad" kvg:element="玲">
 	<g id="kvg:0f9ad-g1" kvg:element="王" kvg:original="玉" kvg:partial="true" kvg:position="left" kvg:radical="general">
 		<path id="kvg:0f9ad-s1" kvg:type="㇐" d="M9.65,28.33c1.53,0.84,5.07,0.34,6.71,0.11c4.56-0.63,10.35-1.83,15.79-2.75c1.41-0.24,3.32-0.74,4.74-0.23"/>
 		<path id="kvg:0f9ad-s2" kvg:type="㇑a" d="M22.42,30.71c1.06,1.06,1.31,2.04,1.31,3.38c0,4.92,0.04,35.9-0.11,39.17"/>
 		<path id="kvg:0f9ad-s3" kvg:type="㇐" d="M10.16,51.37c0.49,0.33,3.93,0.35,4.43,0.31C19,51.25,27.5,49.62,32.44,48.7c0.6-0.11,1.93-0.32,3.25-0.09"/>
 		<path id="kvg:0f9ad-s4" kvg:type="㇐" d="M10.77,78.95c1.03,0.83,2.01,1.11,3.51,0.33c5.6-2.9,10.93-6,18-9.92"/>
 	</g>
-	<g id="kvg:0f9ad-g2" kvg:element="令" kvg:position="right">
+	<g id="kvg:0f9ad-g2" kvg:element="令" kvg:position="right">
 		<g id="kvg:0f9ad-g3" kvg:element="人" kvg:position="top">
 			<path id="kvg:0f9ad-s5" kvg:type="㇒" d="M62.64,12.75c0.08,0.95,0.13,2.52-0.4,3.83C58.5,25.88,50.38,41.12,39,52.35"/>
 			<path id="kvg:0f9ad-s6" kvg:type="㇏" d="M62.92,17.79c8.4,8.61,15.21,17.33,24.47,26.71c2.09,2.12,5.1,4.24,7.37,5.63"/>

--- a/kanji/0f9af.svg
+++ b/kanji/0f9af.svg
@@ -36,7 +36,7 @@ kvg:type CDATA #IMPLIED >
 ]>
 <svg xmlns="http://www.w3.org/2000/svg" width="109" height="109" viewBox="0 0 109 109">
 <g id="kvg:StrokePaths_0f9af" style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;">
-<g id="kvg:0f9af" kvg:element="羚">
+<g id="kvg:0f9af" kvg:element="羚">
 	<g id="kvg:0f9af-g1" kvg:element="羊" kvg:position="left" kvg:radical="general">
 		<path id="kvg:0f9af-s1" kvg:type="㇔" d="M15.79,16.09c3.41,2.12,8.82,8.72,9.68,12.02"/>
 		<path id="kvg:0f9af-s2" kvg:type="㇒" d="M40.64,13.14c0.02,0.38,0.04,0.99-0.04,1.54c-0.53,3.25-3.54,10.39-7.67,14.76"/>
@@ -45,7 +45,7 @@ kvg:type CDATA #IMPLIED >
 		<path id="kvg:0f9af-s5" kvg:type="㇐" d="M12,64.89c0.66,0.77,1.88,0.9,2.54,0.77c5.09-1.05,20.48-6.57,28.71-9.16"/>
 		<path id="kvg:0f9af-s6" kvg:type="㇑" d="M29.78,35.06c0.97,0.94,1.14,2.29,1.14,3.12C30.92,74.25,28.25,86,15,97"/>
 	</g>
-	<g id="kvg:0f9af-g2" kvg:element="令" kvg:position="right">
+	<g id="kvg:0f9af-g2" kvg:element="令" kvg:position="right">
 		<g id="kvg:0f9af-g3" kvg:element="人" kvg:position="top">
 			<path id="kvg:0f9af-s7" kvg:type="㇒" d="M67.02,14c0.07,0.92,0.29,2.4-0.13,3.69C64.24,25.76,55.84,42.28,46,52.1"/>
 			<path id="kvg:0f9af-s8" kvg:type="㇏" d="M67.25,18c4.63,4.66,21.48,23.51,25.39,27.38c1.33,1.31,3.03,1.88,4.36,2.25"/>

--- a/kanji/0f9b0.svg
+++ b/kanji/0f9b0.svg
@@ -36,7 +36,7 @@ kvg:type CDATA #IMPLIED >
 ]>
 <svg xmlns="http://www.w3.org/2000/svg" width="109" height="109" viewBox="0 0 109 109">
 <g id="kvg:StrokePaths_0f9b0" style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;">
-<g id="kvg:0f9b0" kvg:element="聆">
+<g id="kvg:0f9b0" kvg:element="聆">
 	<g id="kvg:0f9b0-g1" kvg:element="耳" kvg:position="left" kvg:radical="general">
 		<path id="kvg:0f9b0-s1" kvg:type="㇐" d="M12.05,19.3c0.75,0.35,2.13,0.4,2.88,0.35c5.97-0.33,17.83-2.62,26.68-3.23c1.25-0.09,2.01,0.17,2.63,0.35"/>
 		<path id="kvg:0f9b0-s2" kvg:type="㇑a" d="M19.37,21.57c0.63,0.68,0.99,2.33,0.99,3.72c0,1.39-0.12,41.3-0.12,46.29"/>
@@ -45,7 +45,7 @@ kvg:type CDATA #IMPLIED >
 		<path id="kvg:0f9b0-s5" kvg:type="㇀" d="M12.25,74.93c0.75,0.82,2.38,0.9,2.94,0.67c2.24-0.92,16.62-7.87,20.06-9.35"/>
 		<path id="kvg:0f9b0-s6" kvg:type="㇑" d="M36.01,20.5c0.77,1.25,0.85,1.46,0.85,2.85s0.12,61.03,0.12,72.4"/>
 	</g>
-	<g id="kvg:0f9b0-g2" kvg:element="令" kvg:position="right">
+	<g id="kvg:0f9b0-g2" kvg:element="令" kvg:position="right">
 		<g id="kvg:0f9b0-g3" kvg:element="人" kvg:position="top">
 			<path id="kvg:0f9b0-s7" kvg:type="㇒" d="M64.89,11.75c0.07,0.97,0.32,2.56-0.14,3.92c-2.92,8.59-11,26.58-23,36.58"/>
 			<path id="kvg:0f9b0-s8" kvg:type="㇏" d="M65.67,14.54c4.76,5.28,22.08,26.65,26.1,31.03c1.37,1.49,3.12,2.13,4.48,2.55"/>

--- a/kanji/0f9b1.svg
+++ b/kanji/0f9b1.svg
@@ -36,7 +36,7 @@ kvg:type CDATA #IMPLIED >
 ]>
 <svg xmlns="http://www.w3.org/2000/svg" width="109" height="109" viewBox="0 0 109 109">
 <g id="kvg:StrokePaths_0f9b1" style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;">
-<g id="kvg:0f9b1" kvg:element="鈴">
+<g id="kvg:0f9b1" kvg:element="鈴">
 	<g id="kvg:0f9b1-g1" kvg:element="金" kvg:position="left" kvg:radical="general">
 		<path id="kvg:0f9b1-s1" kvg:type="㇒" d="M30,14.24c0,1.14-0.05,2.19-0.42,3.28c-1.92,5.7-11.22,20-19.61,28.6"/>
 		<path id="kvg:0f9b1-s2" kvg:type="㇔/㇏" d="M32.39,20.21C37.38,22.75,42.5,26.12,46,31.25"/>
@@ -47,7 +47,7 @@ kvg:type CDATA #IMPLIED >
 		<path id="kvg:0f9b1-s7" kvg:type="㇒" d="M42.48,62.8c0.28,0.69,0.1,1.77-0.18,2.29c-1.29,2.41-2.04,3.78-5.63,8.69"/>
 		<path id="kvg:0f9b1-s8" kvg:type="㇀/㇐" d="M12.75,88.27c1.24,1.24,2.12,1.48,4.18,0.74c1.29-0.47,12.32-4.63,24.82-9.76"/>
 	</g>
-	<g id="kvg:0f9b1-g2" kvg:element="令" kvg:position="right" kvg:phon="令">
+	<g id="kvg:0f9b1-g2" kvg:element="令" kvg:position="right" kvg:phon="令">
 		<g id="kvg:0f9b1-g3" kvg:element="人" kvg:position="top">
 			<path id="kvg:0f9b1-s9" kvg:type="㇒" d="M67.9,13c0.07,1.01-0.2,2.16-0.64,3.57C64.5,25.5,55.75,44,45.5,54.85"/>
 			<path id="kvg:0f9b1-s10" kvg:type="㇏" d="M68.17,17.79c3.99,4.43,15.65,19.54,21.95,26.96c1.93,2.27,4.04,3.86,6.38,5.62"/>

--- a/kanji/0f9b2.svg
+++ b/kanji/0f9b2.svg
@@ -36,7 +36,7 @@ kvg:type CDATA #IMPLIED >
 ]>
 <svg xmlns="http://www.w3.org/2000/svg" width="109" height="109" viewBox="0 0 109 109">
 <g id="kvg:StrokePaths_0f9b2" style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;">
-<g id="kvg:0f9b2" kvg:element="零">
+<g id="kvg:0f9b2" kvg:element="零">
 	<g id="kvg:0f9b2-g1" kvg:element="雨" kvg:variant="true" kvg:position="top" kvg:radical="general">
 		<path id="kvg:0f9b2-s1" kvg:type="㇐" d="M33.21,16.07c2.36,0.32,4.67,0.13,7.03-0.08c7-0.64,17.79-1.78,26.14-2.39c2.44-0.18,4.94-0.51,7.37-0.1"/>
 		<path id="kvg:0f9b2-s2" kvg:type="㇔/㇑" d="M20.29,26.75c-0.2,4.96-1.94,10.46-3.23,15.47"/>
@@ -47,7 +47,7 @@ kvg:type CDATA #IMPLIED >
 		<path id="kvg:0f9b2-s7" kvg:type="㇔" d="M66.68,33.27c3.41,1.4,7.28,4.19,8.65,5.36"/>
 		<path id="kvg:0f9b2-s8" kvg:type="㇔" d="M65.88,44.88c3.13,0.99,7.41,3.97,9.11,5.62"/>
 	</g>
-	<g id="kvg:0f9b2-g2" kvg:element="令" kvg:position="bottom" kvg:phon="令">
+	<g id="kvg:0f9b2-g2" kvg:element="令" kvg:position="bottom" kvg:phon="令">
 		<g id="kvg:0f9b2-g3" kvg:element="人" kvg:position="top">
 			<path id="kvg:0f9b2-s9" kvg:type="㇒" d="M51.87,46.75c0,1.44-0.65,2.54-1.47,3.65c-5.17,7.05-16.3,16.71-35.15,27.28"/>
 			<path id="kvg:0f9b2-s10" kvg:type="㇏" d="M53.04,49.32c5.89,3.64,21.19,14.05,29.63,19.18c2.79,1.7,5.66,3.56,8.83,4.43"/>

--- a/kanji/0f9b4.svg
+++ b/kanji/0f9b4.svg
@@ -36,8 +36,8 @@ kvg:type CDATA #IMPLIED >
 ]>
 <svg xmlns="http://www.w3.org/2000/svg" width="109" height="109" viewBox="0 0 109 109">
 <g id="kvg:StrokePaths_0f9b4" style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;">
-<g id="kvg:0f9b4" kvg:element="領">
-	<g id="kvg:0f9b4-g1" kvg:element="令" kvg:position="left" kvg:phon="令">
+<g id="kvg:0f9b4" kvg:element="領">
+	<g id="kvg:0f9b4-g1" kvg:element="令" kvg:position="left" kvg:phon="令">
 		<g id="kvg:0f9b4-g2" kvg:element="人" kvg:position="top">
 			<path id="kvg:0f9b4-s1" kvg:type="㇒" d="M30.75,18c0,1-0.23,1.88-0.61,2.85c-2.64,6.65-8.39,17.03-18.87,26.86"/>
 			<path id="kvg:0f9b4-s2" kvg:type="㇔/㇏" d="M32,22.75c6,4,10.62,9.25,13.92,14.62"/>

--- a/kanji/20b9f.svg
+++ b/kanji/20b9f.svg
@@ -36,7 +36,7 @@ kvg:type CDATA #IMPLIED >
 ]>
 <svg xmlns="http://www.w3.org/2000/svg" width="109" height="109" viewBox="0 0 109 109">
 <g id="kvg:StrokePaths_20b9f" style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;">
-<g id="kvg:20b9f" kvg:element="叱">
+<g id="kvg:20b9f" kvg:element="𠮟">
 	<g id="kvg:20b9f-g1" kvg:element="口" kvg:position="left" kvg:radical="general">
 		<path id="kvg:20b9f-s1" kvg:type="㇑" d="M 14.75,38.79 c 0.92,0.92 1.1,1.79 1.23,2.85 0.97,5.21 1.92,12.07 2.82,19.13 0.29,2.24 0.57,4.5 0.85,6.74"/>
 		<path id="kvg:20b9f-s2" kvg:type="㇕b" d="M 16.08,40.22 c 8.84,-1.95 15.7,-3.23 20.2,-3.96 2.28,-0.37 4.33,0.78 3.91,3.5 -0.85,5.36 -2.16,12.15 -3.57,20.35"/>


### PR DESCRIPTION
In some files, the character used in the `kvg:element` attribute does not match the codepoint which the file is supposed to represent, which could cause trouble for search tools. Most of these stem from 令 being used in place of 令 (which is one of the "CJK Compatibility Ideographs").

Additionally, I noticed that the `id` attributes in `0f9ad.svg` use the code `0f9ab` instead. This has been fixed to avoid conflicts with the `id`s in `0f9ab.svg`.
