### PR TITLE
Fix #141: incorrect id attribute values

### DIFF
--- a/kanji/05178-KaishoVtLst.svg
+++ b/kanji/05178-KaishoVtLst.svg
@@ -35,39 +35,39 @@ xmlns:kvg CDATA #FIXED "http://kanjivg.tagaini.net"
 kvg:type CDATA #IMPLIED >
 ]>
 <svg xmlns="http://www.w3.org/2000/svg" width="109" height="109" viewBox="0 0 109 109">
-<g id="kvg:StrokePaths_05178-KaishoVtlst" style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;">
-<g id="kvg:05178-KaishoVtlst" kvg:element="典">
-	<g id="kvg:05178-KaishoVtlst-g1" kvg:element="曲" kvg:variant="true" kvg:position="top">
-		<g id="kvg:05178-KaishoVtlst-g2" kvg:element="日" kvg:part="1">
-			<path id="kvg:05178-KaishoVtlst-s1" kvg:type="㇑" d="M26.47,32.59c0.41,0.97,0.83,1.46,0.83,2.75c0,1.3,2.88,36.81,2.88,37.46"/>
-			<path id="kvg:05178-KaishoVtlst-s2" kvg:type="㇕" d="M27.98,34.41c3.8-0.61,48.78-5.84,52.12-6.2C82,28,84.25,29,84.02,31.37c-0.35,3.65-2.93,21.58-3.92,36.91"/>
+<g id="kvg:StrokePaths_05178-KaishoVtLst" style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;">
+<g id="kvg:05178-KaishoVtLst" kvg:element="典">
+	<g id="kvg:05178-KaishoVtLst-g1" kvg:element="曲" kvg:variant="true" kvg:position="top">
+		<g id="kvg:05178-KaishoVtLst-g2" kvg:element="日" kvg:part="1">
+			<path id="kvg:05178-KaishoVtLst-s1" kvg:type="㇑" d="M26.47,32.59c0.41,0.97,0.83,1.46,0.83,2.75c0,1.3,2.88,36.81,2.88,37.46"/>
+			<path id="kvg:05178-KaishoVtLst-s2" kvg:type="㇕" d="M27.98,34.41c3.8-0.61,48.78-5.84,52.12-6.2C82,28,84.25,29,84.02,31.37c-0.35,3.65-2.93,21.58-3.92,36.91"/>
 		</g>
-		<g id="kvg:05178-KaishoVtlst-g3" kvg:element="廾">
-			<g id="kvg:05178-KaishoVtlst-g4" kvg:element="十" kvg:part="1">
-				<path id="kvg:05178-KaishoVtlst-s3" kvg:type="㇐" d="M28.59,52.34c12.66-1.34,21.66-2.09,35.15-2.72c1.46-0.07,2.87-0.23,4.23-0.34"/>
+		<g id="kvg:05178-KaishoVtLst-g3" kvg:element="廾">
+			<g id="kvg:05178-KaishoVtLst-g4" kvg:element="十" kvg:part="1">
+				<path id="kvg:05178-KaishoVtLst-s3" kvg:type="㇐" d="M28.59,52.34c12.66-1.34,21.66-2.09,35.15-2.72c1.46-0.07,2.87-0.23,4.23-0.34"/>
 			</g>
-			<g id="kvg:05178-KaishoVtlst-g5" kvg:element="丿" kvg:variant="true">
-			<path id="kvg:05178-KaishoVtlst-s4" kvg:type="㇐" d="M15.75,73.2c1.52,0.54,4.31,0.73,5.82,0.54c11.68-1.49,51.18-4.99,69.11-5.23c2.53-0.03,4.05,0.26,5.31,0.53"/>
+			<g id="kvg:05178-KaishoVtLst-g5" kvg:element="丿" kvg:variant="true">
+			<path id="kvg:05178-KaishoVtLst-s4" kvg:type="㇐" d="M15.75,73.2c1.52,0.54,4.31,0.73,5.82,0.54c11.68-1.49,51.18-4.99,69.11-5.23c2.53-0.03,4.05,0.26,5.31,0.53"/>
 			</g>
-			<g id="kvg:05178-KaishoVtlst-g6" kvg:element="十" kvg:part="2">
-				<path id="kvg:05178-KaishoVtlst-s5" kvg:type="㇑" d="M42.72,16.98c0.86,0.41,1.52,1.85,1.55,2.69c0.53,18.24,1.12,42.73,1.71,50.4"/>
+			<g id="kvg:05178-KaishoVtLst-g6" kvg:element="十" kvg:part="2">
+				<path id="kvg:05178-KaishoVtLst-s5" kvg:type="㇑" d="M42.72,16.98c0.86,0.41,1.52,1.85,1.55,2.69c0.53,18.24,1.12,42.73,1.71,50.4"/>
 			</g>
 		</g>
-		<g id="kvg:05178-KaishoVtlst-g7" kvg:element="日" kvg:part="2">
-				<path id="kvg:05178-KaishoVtlst-s6" kvg:type="㇑" d="M64.81,13.25c0.86,0.42,1.6,1.85,1.54,2.69c-1.64,25.07-2.82,35.68-4.01,53.09"/>
+		<g id="kvg:05178-KaishoVtLst-g7" kvg:element="日" kvg:part="2">
+				<path id="kvg:05178-KaishoVtLst-s6" kvg:type="㇑" d="M64.81,13.25c0.86,0.42,1.6,1.85,1.54,2.69c-1.64,25.07-2.82,35.68-4.01,53.09"/>
 		</g>
 	</g>
-	<g id="kvg:05178-KaishoVtlst-g8" kvg:element="八" kvg:position="bottom" kvg:radical="general">
-		<g id="kvg:05178-KaishoVtlst-g9" kvg:position="left">
-			<path id="kvg:05178-KaishoVtlst-s7" kvg:type="㇒" d="M41.25,77.14c0.06,0.46,0.12,1.19-0.11,1.85c-1.36,3.91-9.16,12.48-19.83,17.72"/>
+	<g id="kvg:05178-KaishoVtLst-g8" kvg:element="八" kvg:position="bottom" kvg:radical="general">
+		<g id="kvg:05178-KaishoVtLst-g9" kvg:position="left">
+			<path id="kvg:05178-KaishoVtLst-s7" kvg:type="㇒" d="M41.25,77.14c0.06,0.46,0.12,1.19-0.11,1.85c-1.36,3.91-9.16,12.48-19.83,17.72"/>
 		</g>
-		<g id="kvg:05178-KaishoVtlst-g10" kvg:position="right">
-			<path id="kvg:05178-KaishoVtlst-s8" kvg:type="㇏" d="M66.25,79.37c7.78,2.85,20.1,11.71,22.04,16.13"/>
+		<g id="kvg:05178-KaishoVtLst-g10" kvg:position="right">
+			<path id="kvg:05178-KaishoVtLst-s8" kvg:type="㇏" d="M66.25,79.37c7.78,2.85,20.1,11.71,22.04,16.13"/>
 		</g>
 	</g>
 </g>
 </g>
-<g id="kvg:StrokeNumbers_05178-KaishoVtlst" style="font-size:8;fill:#808080">
+<g id="kvg:StrokeNumbers_05178-KaishoVtLst" style="font-size:8;fill:#808080">
 	<text transform="matrix(1 0 0 1 19.25 41.50)">1</text>
 	<text transform="matrix(1 0 0 1 29.25 29.50)">2</text>
 	<text transform="matrix(1 0 0 1 33.75 48.13)">3</text>

--- a/kanji/053df-VtLst.svg
+++ b/kanji/053df-VtLst.svg
@@ -35,7 +35,7 @@ xmlns:kvg CDATA #FIXED "http://kanjivg.tagaini.net"
 kvg:type CDATA #IMPLIED >
 ]>
 <svg xmlns="http://www.w3.org/2000/svg" width="109" height="109" viewBox="0 0 109 109">
-<g id="kvg:StrokePaths_053df" style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;">
+<g id="kvg:StrokePaths_053df-VtLst" style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;">
 <g id="kvg:053df-VtLst" kvg:element="叟">
 	<g id="kvg:053df-VtLst-g1" kvg:position="top">
 		<g id="kvg:053df-VtLst-g2" kvg:element="臼" kvg:variant="true">
@@ -57,7 +57,7 @@ kvg:type CDATA #IMPLIED >
 	</g>
 </g>
 </g>
-<g id="kvg:StrokeNumbers_053df" style="font-size:8;fill:#808080">
+<g id="kvg:StrokeNumbers_053df-VtLst" style="font-size:8;fill:#808080">
 	<text transform="matrix(1 0 0 1 36.75 14.50)">1</text>
 	<text transform="matrix(1 0 0 1 17.50 34.50)">2</text>
 	<text transform="matrix(1 0 0 1 31.50 32.66)">3</text>

--- a/kanji/05750-VtLst.svg
+++ b/kanji/05750-VtLst.svg
@@ -35,28 +35,28 @@ xmlns:kvg CDATA #FIXED "http://kanjivg.tagaini.net"
 kvg:type CDATA #IMPLIED >
 ]>
 <svg xmlns="http://www.w3.org/2000/svg" width="109" height="109" viewBox="0 0 109 109">
-<g id="kvg:StrokePaths_05750" style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;">
-<g id="kvg:05750" kvg:element="坐">
-	<g id="kvg:05750-g1" kvg:element="从">
-		<g id="kvg:05750-g2" kvg:element="人" kvg:position="left">
-			<path id="kvg:05750-s1" kvg:type="㇒" d="M35.25,27.74c0.09,1.2-0.11,2.35-0.58,3.44c-4.04,8.19-9.23,15.34-18.2,23.7"/>
-			<path id="kvg:05750-s2" kvg:type="㇏" d="M33,40.25c5.12,2.62,9.81,7.05,12.25,12.88"/>
+<g id="kvg:StrokePaths_05750-VtLst" style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;">
+<g id="kvg:05750-VtLst" kvg:element="坐">
+	<g id="kvg:05750-VtLst-g1" kvg:element="从">
+		<g id="kvg:05750-VtLst-g2" kvg:element="人" kvg:position="left">
+			<path id="kvg:05750-VtLst-s1" kvg:type="㇒" d="M35.25,27.74c0.09,1.2-0.11,2.35-0.58,3.44c-4.04,8.19-9.23,15.34-18.2,23.7"/>
+			<path id="kvg:05750-VtLst-s2" kvg:type="㇏" d="M33,40.25c5.12,2.62,9.81,7.05,12.25,12.88"/>
 		</g>
-		<g id="kvg:05750-g3" kvg:element="人" kvg:position="right">
-			<path id="kvg:05750-s3" kvg:type="㇒" d="M79.25,28.74c0,1.13-0.08,2.04-0.59,2.95c-3.29,6.43-8.92,14.43-15.94,20.68"/>
-			<path id="kvg:05750-s4" kvg:type="㇏" d="M78.14,39.71C84,43.5,87.75,47.75,91.25,53.5"/>
+		<g id="kvg:05750-VtLst-g3" kvg:element="人" kvg:position="right">
+			<path id="kvg:05750-VtLst-s3" kvg:type="㇒" d="M79.25,28.74c0,1.13-0.08,2.04-0.59,2.95c-3.29,6.43-8.92,14.43-15.94,20.68"/>
+			<path id="kvg:05750-VtLst-s4" kvg:type="㇏" d="M78.14,39.71C84,43.5,87.75,47.75,91.25,53.5"/>
 		</g>
 	</g>
-	<g id="kvg:05750-g4" kvg:element="土" kvg:radical="tradit">
-		<path id="kvg:05750-s5" kvg:type="㇐" d="M25.63,67.42c2.99,0.5,5.99,0.53,9,0.11c11.48-1.12,28.2-2.57,39.75-3.15c2.93-0.38,5.85-0.07,8.75,0.41"/>
-		<g id="kvg:05750-g5" kvg:element="一" kvg:radical="nelson">
-			<path id="kvg:05750-s6" kvg:type="㇐" d="M15.13,89.73c4.19,0.65,8.4,0.74,12.62,0.27c16.35-1.21,38.53-2.4,54-3.12c4.31-0.1,8.61,0.13,12.88,0.69"/>
+	<g id="kvg:05750-VtLst-g4" kvg:element="土" kvg:radical="tradit">
+		<path id="kvg:05750-VtLst-s5" kvg:type="㇐" d="M25.63,67.42c2.99,0.5,5.99,0.53,9,0.11c11.48-1.12,28.2-2.57,39.75-3.15c2.93-0.38,5.85-0.07,8.75,0.41"/>
+		<g id="kvg:05750-VtLst-g5" kvg:element="一" kvg:radical="nelson">
+			<path id="kvg:05750-VtLst-s6" kvg:type="㇐" d="M15.13,89.73c4.19,0.65,8.4,0.74,12.62,0.27c16.35-1.21,38.53-2.4,54-3.12c4.31-0.1,8.61,0.13,12.88,0.69"/>
 		</g>
-		<path id="kvg:05750-s7" kvg:type="㇑" d="M53.17,15.62c0.98,0.98,1.27,2.26,1.27,3.89c0,12-0.07,52.38-0.07,67.75"/>
+		<path id="kvg:05750-VtLst-s7" kvg:type="㇑" d="M53.17,15.62c0.98,0.98,1.27,2.26,1.27,3.89c0,12-0.07,52.38-0.07,67.75"/>
 	</g>
 </g>
 </g>
-<g id="kvg:StrokeNumbers_05750" style="font-size:8;fill:#808080">
+<g id="kvg:StrokeNumbers_05750-VtLst" style="font-size:8;fill:#808080">
 	<text transform="matrix(1 0 0 1 27.50 28.50)">1</text>
 	<text transform="matrix(1 0 0 1 39.50 41.50)">2</text>
 	<text transform="matrix(1 0 0 1 70.50 28.50)">3</text>

--- a/kanji/05ea7-KaishoVtLst.svg
+++ b/kanji/05ea7-KaishoVtLst.svg
@@ -35,35 +35,35 @@ xmlns:kvg CDATA #FIXED "http://kanjivg.tagaini.net"
 kvg:type CDATA #IMPLIED >
 ]>
 <svg xmlns="http://www.w3.org/2000/svg" width="109" height="109" viewBox="0 0 109 109">
-<g id="kvg:StrokePaths_05ea7-Kaisho" style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;">
-<g id="kvg:05ea7-Kaisho" kvg:element="座">
-	<g id="kvg:05ea7-Kaisho-g1" kvg:element="广" kvg:position="tare" kvg:radical="general">
-		<path id="kvg:05ea7-Kaisho-s1" kvg:type="㇑a" d="M50.27,13.13c2.73,0.93,8.53,6.95,9.07,8.8"/>
-		<g id="kvg:05ea7-Kaisho-g2" kvg:element="厂">
-			<path id="kvg:05ea7-Kaisho-s2" kvg:type="㇐" d="M21.13,28.73c1.52,0.54,4.3,0.63,5.82,0.54c15.8-0.91,38.05-2.77,56.11-3.73c2.53-0.13,4.05,0.26,5.31,0.53"/>
-			<path id="kvg:05ea7-Kaisho-s3" kvg:type="㇒" d="M25,31.5c0.04,1.46,0.09,3.76-0.09,5.86C23.87,49.71,22.75,80,10.31,92.97"/>
+<g id="kvg:StrokePaths_05ea7-KaishoVtLst" style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;">
+<g id="kvg:05ea7-KaishoVtLst" kvg:element="座">
+	<g id="kvg:05ea7-KaishoVtLst-g1" kvg:element="广" kvg:position="tare" kvg:radical="general">
+		<path id="kvg:05ea7-KaishoVtLst-s1" kvg:type="㇑a" d="M50.27,13.13c2.73,0.93,8.53,6.95,9.07,8.8"/>
+		<g id="kvg:05ea7-KaishoVtLst-g2" kvg:element="厂">
+			<path id="kvg:05ea7-KaishoVtLst-s2" kvg:type="㇐" d="M21.13,28.73c1.52,0.54,4.3,0.63,5.82,0.54c15.8-0.91,38.05-2.77,56.11-3.73c2.53-0.13,4.05,0.26,5.31,0.53"/>
+			<path id="kvg:05ea7-KaishoVtLst-s3" kvg:type="㇒" d="M25,31.5c0.04,1.46,0.09,3.76-0.09,5.86C23.87,49.71,22.75,80,10.31,92.97"/>
 		</g>
 	</g>
-	<g id="kvg:05ea7-Kaisho-g3" kvg:element="坐">
-		<g id="kvg:05ea7-Kaisho-g4" kvg:element="从">
-			<g id="kvg:05ea7-Kaisho-g5" kvg:element="人" kvg:position="left">
-				<path id="kvg:05ea7-Kaisho-s4" kvg:type="㇒" d="M43.6,40.3c0,0.58,0.07,1.07-0.12,1.75c-1.76,6.33-7.03,14.21-14.77,21.21"/>
-				<path id="kvg:05ea7-Kaisho-s5" kvg:type="㇏" d="M40.7,50.13c4.03,1.94,9.17,7.09,11.13,11.98"/>
+	<g id="kvg:05ea7-KaishoVtLst-g3" kvg:element="坐">
+		<g id="kvg:05ea7-KaishoVtLst-g4" kvg:element="从">
+			<g id="kvg:05ea7-KaishoVtLst-g5" kvg:element="人" kvg:position="left">
+				<path id="kvg:05ea7-KaishoVtLst-s4" kvg:type="㇒" d="M43.6,40.3c0,0.58,0.07,1.07-0.12,1.75c-1.76,6.33-7.03,14.21-14.77,21.21"/>
+				<path id="kvg:05ea7-KaishoVtLst-s5" kvg:type="㇏" d="M40.7,50.13c4.03,1.94,9.17,7.09,11.13,11.98"/>
 			</g>
-			<g id="kvg:05ea7-Kaisho-g6" kvg:element="人" kvg:position="right">
-				<path id="kvg:05ea7-Kaisho-s6" kvg:type="㇒" d="M79.02,39.42c0,0.5,0.1,0.93-0.1,1.5c-1.71,4.89-6.57,13.59-12.36,18.52"/>
-				<path id="kvg:05ea7-Kaisho-s7" kvg:type="㇏" d="M77.96,48.52c4.55,3.14,8.04,7.08,10.76,11.85"/>
+			<g id="kvg:05ea7-KaishoVtLst-g6" kvg:element="人" kvg:position="right">
+				<path id="kvg:05ea7-KaishoVtLst-s6" kvg:type="㇒" d="M79.02,39.42c0,0.5,0.1,0.93-0.1,1.5c-1.71,4.89-6.57,13.59-12.36,18.52"/>
+				<path id="kvg:05ea7-KaishoVtLst-s7" kvg:type="㇏" d="M77.96,48.52c4.55,3.14,8.04,7.08,10.76,11.85"/>
 			</g>
 		</g>
-		<g id="kvg:05ea7-Kaisho-g7" kvg:element="土">
-			<path id="kvg:05ea7-Kaisho-s8" kvg:type="㇐" d="M37.06,75.12c0.81,0.32,2.31,0.4,3.12,0.32c10.46-1.08,26.19-2.94,36.72-3.22c1.36-0.04,2.17,0.15,2.85,0.31"/>
-			<path id="kvg:05ea7-Kaisho-s9" kvg:type="㇐" d="M25.73,93.83c1.26,0.45,3.57,0.55,4.83,0.45c15.59-1.26,43.37-2.92,57.32-3.51c2.1-0.09,3.36,0.22,4.41,0.44"/>
-			<path id="kvg:05ea7-Kaisho-s10" kvg:type="㇑a" d="M57.28,34.87c0.1,0.24,1.47,1.26,1.47,2.81c0,9.95,0.12,41.45,0.12,54.61"/>
+		<g id="kvg:05ea7-KaishoVtLst-g7" kvg:element="土">
+			<path id="kvg:05ea7-KaishoVtLst-s8" kvg:type="㇐" d="M37.06,75.12c0.81,0.32,2.31,0.4,3.12,0.32c10.46-1.08,26.19-2.94,36.72-3.22c1.36-0.04,2.17,0.15,2.85,0.31"/>
+			<path id="kvg:05ea7-KaishoVtLst-s9" kvg:type="㇐" d="M25.73,93.83c1.26,0.45,3.57,0.55,4.83,0.45c15.59-1.26,43.37-2.92,57.32-3.51c2.1-0.09,3.36,0.22,4.41,0.44"/>
+			<path id="kvg:05ea7-KaishoVtLst-s10" kvg:type="㇑a" d="M57.28,34.87c0.1,0.24,1.47,1.26,1.47,2.81c0,9.95,0.12,41.45,0.12,54.61"/>
 		</g>
 	</g>
 </g>
 </g>
-<g id="kvg:StrokeNumbers_05ea7-Kaisho" style="font-size:8;fill:#808080">
+<g id="kvg:StrokeNumbers_05ea7-KaishoVtLst" style="font-size:8;fill:#808080">
 	<text transform="matrix(1 0 0 1 44.50 13.50)">1</text>
 	<text transform="matrix(1 0 0 1 24.75 26.50)">2</text>
 	<text transform="matrix(1 0 0 1 17.25 37.50)">3</text>

--- a/kanji/05ea7-VtLst.svg
+++ b/kanji/05ea7-VtLst.svg
@@ -35,35 +35,35 @@ xmlns:kvg CDATA #FIXED "http://kanjivg.tagaini.net"
 kvg:type CDATA #IMPLIED >
 ]>
 <svg xmlns="http://www.w3.org/2000/svg" width="109" height="109" viewBox="0 0 109 109">
-<g id="kvg:StrokePaths_05ea7" style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;">
-<g id="kvg:05ea7" kvg:element="座">
-	<g id="kvg:05ea7-g1" kvg:element="广" kvg:position="tare" kvg:radical="general">
-		<path id="kvg:05ea7-s1" kvg:type="㇑a" d="M53.81,13.88c1.22,1.22,1.51,2.87,1.51,4.4c0,0.79-0.07,4.96-0.07,7.71"/>
-		<g id="kvg:05ea7-g2" kvg:element="厂">
-			<path id="kvg:05ea7-s2" kvg:type="㇐" d="M21.13,28.82c2.87,0.68,6.55,0.48,9.61,0.24c15.51-1.19,32.65-2.29,48.51-3.1c3.13-0.16,6.05-0.3,9.13,0.28"/>
-			<path id="kvg:05ea7-s3" kvg:type="㇒" d="M24,29.5c0.88,0.88,1.2,2.13,1.16,3.36c-0.66,21.77-1.78,40.89-14.85,60.11"/>
+<g id="kvg:StrokePaths_05ea7-VtLst" style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;">
+<g id="kvg:05ea7-VtLst" kvg:element="座">
+	<g id="kvg:05ea7-VtLst-g1" kvg:element="广" kvg:position="tare" kvg:radical="general">
+		<path id="kvg:05ea7-VtLst-s1" kvg:type="㇑a" d="M53.81,13.88c1.22,1.22,1.51,2.87,1.51,4.4c0,0.79-0.07,4.96-0.07,7.71"/>
+		<g id="kvg:05ea7-VtLst-g2" kvg:element="厂">
+			<path id="kvg:05ea7-VtLst-s2" kvg:type="㇐" d="M21.13,28.82c2.87,0.68,6.55,0.48,9.61,0.24c15.51-1.19,32.65-2.29,48.51-3.1c3.13-0.16,6.05-0.3,9.13,0.28"/>
+			<path id="kvg:05ea7-VtLst-s3" kvg:type="㇒" d="M24,29.5c0.88,0.88,1.2,2.13,1.16,3.36c-0.66,21.77-1.78,40.89-14.85,60.11"/>
 		</g>
 	</g>
-	<g id="kvg:05ea7-g3" kvg:element="坐" kvg:phon="坐">
-		<g id="kvg:05ea7-g4" kvg:element="从">
-			<g id="kvg:05ea7-g5" kvg:element="人" kvg:position="left">
-				<path id="kvg:05ea7-s4" kvg:type="㇒" d="M43.35,41.05c0.06,1.13-0.13,2.21-0.59,3.25C40.69,50.16,36,56.23,28.71,63.26"/>
-				<path id="kvg:05ea7-s5" kvg:type="㇔/㇏" d="M42.75,51c3.28,1.76,7.48,6.43,9.08,10.86"/>
+	<g id="kvg:05ea7-VtLst-g3" kvg:element="坐" kvg:phon="坐">
+		<g id="kvg:05ea7-VtLst-g4" kvg:element="从">
+			<g id="kvg:05ea7-VtLst-g5" kvg:element="人" kvg:position="left">
+				<path id="kvg:05ea7-VtLst-s4" kvg:type="㇒" d="M43.35,41.05c0.06,1.13-0.13,2.21-0.59,3.25C40.69,50.16,36,56.23,28.71,63.26"/>
+				<path id="kvg:05ea7-VtLst-s5" kvg:type="㇔/㇏" d="M42.75,51c3.28,1.76,7.48,6.43,9.08,10.86"/>
 			</g>
-			<g id="kvg:05ea7-g6" kvg:element="人" kvg:position="right">
-				<path id="kvg:05ea7-s6" kvg:type="㇒" d="M78.77,39.42c0.08,1.1,0.09,2.13-0.46,3.1c-2.03,4.88-6.2,11.76-11.74,17.42"/>
-				<path id="kvg:05ea7-s7" kvg:type="㇔/㇏" d="M78.62,49.75c3.95,2.88,6.99,6.49,9.35,10.87"/>
+			<g id="kvg:05ea7-VtLst-g6" kvg:element="人" kvg:position="right">
+				<path id="kvg:05ea7-VtLst-s6" kvg:type="㇒" d="M78.77,39.42c0.08,1.1,0.09,2.13-0.46,3.1c-2.03,4.88-6.2,11.76-11.74,17.42"/>
+				<path id="kvg:05ea7-VtLst-s7" kvg:type="㇔/㇏" d="M78.62,49.75c3.95,2.88,6.99,6.49,9.35,10.87"/>
 			</g>
 		</g>
-		<g id="kvg:05ea7-g7" kvg:element="土">
-			<path id="kvg:05ea7-s8" kvg:type="㇐" d="M37.31,74.62c1.57,0.38,4.01,0.5,5.56,0.34c8.95-0.94,20.41-2.36,29.76-2.83c2.27-0.11,4.9-0.12,7.11,0.39"/>
-			<path id="kvg:05ea7-s9" kvg:type="㇐" d="M25.73,93.33c2.79,0.99,6.64,0.55,9.53,0.34c14.21-1.03,34.73-1.85,47.99-2.45c3.08-0.14,6.04,0.1,9.03,0.74"/>
-			<path id="kvg:05ea7-s10" kvg:type="㇑a" d="M57.53,34.87c0.74,0.74,1.22,2.01,1.22,3.56c0,9.95,0,39.29,0,52.7"/>
+		<g id="kvg:05ea7-VtLst-g7" kvg:element="土">
+			<path id="kvg:05ea7-VtLst-s8" kvg:type="㇐" d="M37.31,74.62c1.57,0.38,4.01,0.5,5.56,0.34c8.95-0.94,20.41-2.36,29.76-2.83c2.27-0.11,4.9-0.12,7.11,0.39"/>
+			<path id="kvg:05ea7-VtLst-s9" kvg:type="㇐" d="M25.73,93.33c2.79,0.99,6.64,0.55,9.53,0.34c14.21-1.03,34.73-1.85,47.99-2.45c3.08-0.14,6.04,0.1,9.03,0.74"/>
+			<path id="kvg:05ea7-VtLst-s10" kvg:type="㇑a" d="M57.53,34.87c0.74,0.74,1.22,2.01,1.22,3.56c0,9.95,0,39.29,0,52.7"/>
 		</g>
 	</g>
 </g>
 </g>
-<g id="kvg:StrokeNumbers_05ea7" style="font-size:8;fill:#808080">
+<g id="kvg:StrokeNumbers_05ea7-VtLst" style="font-size:8;fill:#808080">
 	<text transform="matrix(1 0 0 1 46.50 13.50)">1</text>
 	<text transform="matrix(1 0 0 1 24.75 26.50)">2</text>
 	<text transform="matrix(1 0 0 1 17.25 37.50)">3</text>

--- a/kanji/0632b-VtLst.svg
+++ b/kanji/0632b-VtLst.svg
@@ -35,33 +35,33 @@ xmlns:kvg CDATA #FIXED "http://kanjivg.tagaini.net"
 kvg:type CDATA #IMPLIED >
 ]>
 <svg xmlns="http://www.w3.org/2000/svg" width="109" height="109" viewBox="0 0 109 109">
-<g id="kvg:StrokePaths_0632b" style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;">
-<g id="kvg:0632b" kvg:element="挫">
-	<g id="kvg:0632b-g1" kvg:element="扌" kvg:variant="true" kvg:original="手" kvg:position="left" kvg:radical="general">
-		<path id="kvg:0632b-s1" kvg:type="㇐" d="M12.25,38.5c2.18,0.26,4.13,0.42,6.37,0.09c4.93-0.75,12.86-1.64,19.77-2.57c1.11-0.15,2.36-0.18,3.27-0.18"/>
-		<path id="kvg:0632b-s2" kvg:type="㇚" d="M29.27,14.33c1.01,1.01,1.26,2.42,1.26,4.27c0,14.56-0.01,64.69-0.01,69.65c0,14.25-6.07,3.53-7.52,2"/>
-		<path id="kvg:0632b-s3" kvg:type="㇀" d="M12.25,67.23c1.66,0.75,3.06,0.37,4.45-0.61c9.18-6.49,13.18-9.24,21.05-15.62"/>
+<g id="kvg:StrokePaths_0632b-VtLst" style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;">
+<g id="kvg:0632b-VtLst" kvg:element="挫">
+	<g id="kvg:0632b-VtLst-g1" kvg:element="扌" kvg:variant="true" kvg:original="手" kvg:position="left" kvg:radical="general">
+		<path id="kvg:0632b-VtLst-s1" kvg:type="㇐" d="M12.25,38.5c2.18,0.26,4.13,0.42,6.37,0.09c4.93-0.75,12.86-1.64,19.77-2.57c1.11-0.15,2.36-0.18,3.27-0.18"/>
+		<path id="kvg:0632b-VtLst-s2" kvg:type="㇚" d="M29.27,14.33c1.01,1.01,1.26,2.42,1.26,4.27c0,14.56-0.01,64.69-0.01,69.65c0,14.25-6.07,3.53-7.52,2"/>
+		<path id="kvg:0632b-VtLst-s3" kvg:type="㇀" d="M12.25,67.23c1.66,0.75,3.06,0.37,4.45-0.61c9.18-6.49,13.18-9.24,21.05-15.62"/>
 	</g>
-	<g id="kvg:0632b-g2" kvg:element="坐" kvg:position="right">
-		<g id="kvg:0632b-g3" kvg:element="从">
-			<g id="kvg:0632b-g4" kvg:element="人" kvg:position="left">
-				<path id="kvg:0632b-s4" kvg:type="㇒" d="M55.25,32.49c0,1.38-0.29,2.25-0.72,3.31c-2.27,7.31-5.65,13.63-12.32,23.83"/>
-				<path id="kvg:0632b-s5" kvg:type="㇏" d="M54.25,45.88c3.88,2.62,6.62,6.75,7.75,10.88"/>
+	<g id="kvg:0632b-VtLst-g2" kvg:element="坐" kvg:position="right">
+		<g id="kvg:0632b-VtLst-g3" kvg:element="从">
+			<g id="kvg:0632b-VtLst-g4" kvg:element="人" kvg:position="left">
+				<path id="kvg:0632b-VtLst-s4" kvg:type="㇒" d="M55.25,32.49c0,1.38-0.29,2.25-0.72,3.31c-2.27,7.31-5.65,13.63-12.32,23.83"/>
+				<path id="kvg:0632b-VtLst-s5" kvg:type="㇏" d="M54.25,45.88c3.88,2.62,6.62,6.75,7.75,10.88"/>
 			</g>
-			<g id="kvg:0632b-g5" kvg:element="人" kvg:position="right">
-				<path id="kvg:0632b-s6" kvg:type="㇒" d="M87.51,32.49c0.09,0.96-0.03,1.88-0.36,2.76C84.62,42,81.38,48.38,75.22,56.88"/>
-				<path id="kvg:0632b-s7" kvg:type="㇏" d="M87.12,44.5c4.25,3.62,7.25,7.88,8.62,11.25"/>
+			<g id="kvg:0632b-VtLst-g5" kvg:element="人" kvg:position="right">
+				<path id="kvg:0632b-VtLst-s6" kvg:type="㇒" d="M87.51,32.49c0.09,0.96-0.03,1.88-0.36,2.76C84.62,42,81.38,48.38,75.22,56.88"/>
+				<path id="kvg:0632b-VtLst-s7" kvg:type="㇏" d="M87.12,44.5c4.25,3.62,7.25,7.88,8.62,11.25"/>
 			</g>
 		</g>
-		<g id="kvg:0632b-g6" kvg:element="土">
-			<path id="kvg:0632b-s8" kvg:type="㇐" d="M47.63,69.67c2.71,0.53,5.37,0.2,8.13-0.07c9.74-0.97,17.25-1.83,26.37-2.25c2.82-0.13,5.49,0.05,8.25,0.7"/>
-			<path id="kvg:0632b-s9" kvg:type="㇐" d="M40.13,90.48c3.93,0.95,7.84,0.73,11.87,0.32c12.63-1.29,20.51-1.67,34.02-1.97c4.1-0.09,8.12,0.13,12.12,0.99"/>
-			<path id="kvg:0632b-s10" kvg:type="㇑a" d="M67.42,13.87c0.79,0.79,1.27,2.26,1.27,3.89c0,12.37-0.07,55.01-0.07,71.12"/>
+		<g id="kvg:0632b-VtLst-g6" kvg:element="土">
+			<path id="kvg:0632b-VtLst-s8" kvg:type="㇐" d="M47.63,69.67c2.71,0.53,5.37,0.2,8.13-0.07c9.74-0.97,17.25-1.83,26.37-2.25c2.82-0.13,5.49,0.05,8.25,0.7"/>
+			<path id="kvg:0632b-VtLst-s9" kvg:type="㇐" d="M40.13,90.48c3.93,0.95,7.84,0.73,11.87,0.32c12.63-1.29,20.51-1.67,34.02-1.97c4.1-0.09,8.12,0.13,12.12,0.99"/>
+			<path id="kvg:0632b-VtLst-s10" kvg:type="㇑a" d="M67.42,13.87c0.79,0.79,1.27,2.26,1.27,3.89c0,12.37-0.07,55.01-0.07,71.12"/>
 		</g>
 	</g>
 </g>
 </g>
-<g id="kvg:StrokeNumbers_0632b" style="font-size:8;fill:#808080">
+<g id="kvg:StrokeNumbers_0632b-VtLst" style="font-size:8;fill:#808080">
 	<text transform="matrix(1 0 0 1 5.50 39.50)">1</text>
 	<text transform="matrix(1 0 0 1 19.50 14.50)">2</text>
 	<text transform="matrix(1 0 0 1 4.50 69.50)">3</text>

--- a/kanji/06923-KaishoVtLst.svg
+++ b/kanji/06923-KaishoVtLst.svg
@@ -35,47 +35,47 @@ xmlns:kvg CDATA #FIXED "http://kanjivg.tagaini.net"
 kvg:type CDATA #IMPLIED >
 ]>
 <svg xmlns="http://www.w3.org/2000/svg" width="109" height="109" viewBox="0 0 109 109">
-<g id="kvg:StrokePaths_06923-KaishoVtlst" style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;">
-<g id="kvg:06923-KaishoVtlst" kvg:element="椣">
-	<g id="kvg:06923-KaishoVtlst-g1" kvg:element="木" kvg:position="left" kvg:radical="general">
-		<path id="kvg:06923-KaishoVtlst-s1" kvg:type="㇐" d="M12.28,38.72c0.35,0.24,2.39,0.41,3.31,0.31c3.94-0.41,17.12-1.21,23.45-2.41c0.92-0.17,2.15-0.24,2.73,0"/>
-		<path id="kvg:06923-KaishoVtlst-s2" kvg:type="㇑" d="M27.86,14c0.91,0.47,2.04,2.75,2.04,4.42c0,0.95-0.3,72.73-0.3,73.58c0,11-4.35,2.75-5.85,1.25"/>
-		<path id="kvg:06923-KaishoVtlst-s3" kvg:type="㇒" d="M29.94,40.28c-5.1,15.04-7.94,23.4-15.83,36.56"/>
-		<path id="kvg:06923-KaishoVtlst-s4" kvg:type="㇔/㇏" d="M32.47,49.15c2.52,1.8,6.66,7.62,8.78,11.1"/>
+<g id="kvg:StrokePaths_06923-KaishoVtLst" style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;">
+<g id="kvg:06923-KaishoVtLst" kvg:element="椣">
+	<g id="kvg:06923-KaishoVtLst-g1" kvg:element="木" kvg:position="left" kvg:radical="general">
+		<path id="kvg:06923-KaishoVtLst-s1" kvg:type="㇐" d="M12.28,38.72c0.35,0.24,2.39,0.41,3.31,0.31c3.94-0.41,17.12-1.21,23.45-2.41c0.92-0.17,2.15-0.24,2.73,0"/>
+		<path id="kvg:06923-KaishoVtLst-s2" kvg:type="㇑" d="M27.86,14c0.91,0.47,2.04,2.75,2.04,4.42c0,0.95-0.3,72.73-0.3,73.58c0,11-4.35,2.75-5.85,1.25"/>
+		<path id="kvg:06923-KaishoVtLst-s3" kvg:type="㇒" d="M29.94,40.28c-5.1,15.04-7.94,23.4-15.83,36.56"/>
+		<path id="kvg:06923-KaishoVtLst-s4" kvg:type="㇔/㇏" d="M32.47,49.15c2.52,1.8,6.66,7.62,8.78,11.1"/>
 	</g>
-	<g id="kvg:06923-KaishoVtlst-g2" kvg:element="典" kvg:position="right">
-		<g id="kvg:06923-KaishoVtlst-g3" kvg:element="曲" kvg:variant="true" kvg:position="top">
-			<g id="kvg:06923-KaishoVtlst-g4" kvg:element="日" kvg:part="1">
-				<path id="kvg:06923-KaishoVtlst-s5" kvg:type="㇑" d="M48.48,34.11c0.3,0.96,1.1,1.44,1.1,2.72c0,1.27,2.11,37.65,2.11,38.28"/>
-				<path id="kvg:06923-KaishoVtlst-s6" kvg:type="㇕" d="M50.07,36.92c2.74-0.52,35.7-3.34,38.11-3.64c1.37-0.17,3,0.85,2.83,3.18c-0.25,3.57-2.1,21.11-2.8,36.12"/>
+	<g id="kvg:06923-KaishoVtLst-g2" kvg:element="典" kvg:position="right">
+		<g id="kvg:06923-KaishoVtLst-g3" kvg:element="曲" kvg:variant="true" kvg:position="top">
+			<g id="kvg:06923-KaishoVtLst-g4" kvg:element="日" kvg:part="1">
+				<path id="kvg:06923-KaishoVtLst-s5" kvg:type="㇑" d="M48.48,34.11c0.3,0.96,1.1,1.44,1.1,2.72c0,1.27,2.11,37.65,2.11,38.28"/>
+				<path id="kvg:06923-KaishoVtLst-s6" kvg:type="㇕" d="M50.07,36.92c2.74-0.52,35.7-3.34,38.11-3.64c1.37-0.17,3,0.85,2.83,3.18c-0.25,3.57-2.1,21.11-2.8,36.12"/>
 			</g>
-			<g id="kvg:06923-KaishoVtlst-g5" kvg:element="廾">
-				<g id="kvg:06923-KaishoVtlst-g6" kvg:element="十" kvg:part="1">
-					<path id="kvg:06923-KaishoVtlst-s7" kvg:type="㇐" d="M50.53,54.53C61,54,69.74,53.65,78.23,53.19c1.06-0.06,2.1-0.11,3.09-0.17"/>
+			<g id="kvg:06923-KaishoVtLst-g5" kvg:element="廾">
+				<g id="kvg:06923-KaishoVtLst-g6" kvg:element="十" kvg:part="1">
+					<path id="kvg:06923-KaishoVtLst-s7" kvg:type="㇐" d="M50.53,54.53C61,54,69.74,53.65,78.23,53.19c1.06-0.06,2.1-0.11,3.09-0.17"/>
 				</g>
-				<g id="kvg:06923-KaishoVtlst-g7" kvg:element="丿" kvg:variant="true">
-					<path id="kvg:06923-KaishoVtlst-s8" kvg:type="㇑" d="M38.02,75.73c1.17,0.53,3.32,0.76,4.48,0.6c8.98-1.19,39.37-3.76,53.17-3.68c1.95,0.01,3.12,0.31,4.09,0.58"/>
+				<g id="kvg:06923-KaishoVtLst-g7" kvg:element="丿" kvg:variant="true">
+					<path id="kvg:06923-KaishoVtLst-s8" kvg:type="㇑" d="M38.02,75.73c1.17,0.53,3.32,0.76,4.48,0.6c8.98-1.19,39.37-3.76,53.17-3.68c1.95,0.01,3.12,0.31,4.09,0.58"/>
 				</g>
-				<g id="kvg:06923-KaishoVtlst-g8" kvg:element="十" kvg:part="2">
-					<path id="kvg:06923-KaishoVtlst-s9" kvg:type="㇑" d="M58.8,14.6c1.08,0.48,1.92,2.12,1.96,3.08c0.7,20.64,1.98,47.85,2.74,56.53"/>
+				<g id="kvg:06923-KaishoVtLst-g8" kvg:element="十" kvg:part="2">
+					<path id="kvg:06923-KaishoVtLst-s9" kvg:type="㇑" d="M58.8,14.6c1.08,0.48,1.92,2.12,1.96,3.08c0.7,20.64,1.98,47.85,2.74,56.53"/>
 				</g>
 			</g>
-			<g id="kvg:06923-KaishoVtlst-g9" kvg:element="日" kvg:part="2">
-				<path id="kvg:06923-KaishoVtlst-s10" kvg:type="㇐" d="M75.63,13.84c0.62,0.45,1.15,1.97,1.12,2.86c-1.16,26.35-0.51,37.49-1.34,55.79"/>
+			<g id="kvg:06923-KaishoVtLst-g9" kvg:element="日" kvg:part="2">
+				<path id="kvg:06923-KaishoVtLst-s10" kvg:type="㇐" d="M75.63,13.84c0.62,0.45,1.15,1.97,1.12,2.86c-1.16,26.35-0.51,37.49-1.34,55.79"/>
 			</g>
 		</g>
-		<g id="kvg:06923-KaishoVtlst-g10" kvg:element="八" kvg:position="bottom">
-			<g id="kvg:06923-KaishoVtlst-g11" kvg:position="left">
-				<path id="kvg:06923-KaishoVtlst-s11" kvg:type="㇒" d="M59.63,82.33c0.05,0.39,0.11,1.02-0.1,1.58c-1.23,3.3-8.29,10.48-17.97,14.78"/>
+		<g id="kvg:06923-KaishoVtLst-g10" kvg:element="八" kvg:position="bottom">
+			<g id="kvg:06923-KaishoVtLst-g11" kvg:position="left">
+				<path id="kvg:06923-KaishoVtLst-s11" kvg:type="㇒" d="M59.63,82.33c0.05,0.39,0.11,1.02-0.1,1.58c-1.23,3.3-8.29,10.48-17.97,14.78"/>
 			</g>
-			<g id="kvg:06923-KaishoVtlst-g12" kvg:position="right">
-				<path id="kvg:06923-KaishoVtlst-s12" kvg:type="㇏" d="M77.88,82.83c5.99,2.78,15.47,11.23,16.97,15.37"/>
+			<g id="kvg:06923-KaishoVtLst-g12" kvg:position="right">
+				<path id="kvg:06923-KaishoVtLst-s12" kvg:type="㇏" d="M77.88,82.83c5.99,2.78,15.47,11.23,16.97,15.37"/>
 			</g>
 		</g>
 	</g>
 </g>
 </g>
-<g id="kvg:StrokeNumbers_06923-KaishoVtlst" style="font-size:8;fill:#808080">
+<g id="kvg:StrokeNumbers_06923-KaishoVtLst" style="font-size:8;fill:#808080">
 	<text transform="matrix(1 0 0 1 6.50 39.50)">1</text>
 	<text transform="matrix(1 0 0 1 19.50 13.50)">2</text>
 	<text transform="matrix(1 0 0 1 20.50 48.50)">3</text>

--- a/kanji/08146-KaishoVtLst.svg
+++ b/kanji/08146-KaishoVtLst.svg
@@ -35,47 +35,47 @@ xmlns:kvg CDATA #FIXED "http://kanjivg.tagaini.net"
 kvg:type CDATA #IMPLIED >
 ]>
 <svg xmlns="http://www.w3.org/2000/svg" width="109" height="109" viewBox="0 0 109 109">
-<g id="kvg:StrokePaths_08146-KaishoVtlst" style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;">
-<g id="kvg:08146-KaishoVtlst" kvg:element="腆">
-	<g id="kvg:08146-KaishoVtlst-g1" kvg:element="月" kvg:variant="true" kvg:original="肉" kvg:position="left" kvg:radical="general">
-		<path id="kvg:08146-KaishoVtlst-s1" kvg:type="㇒" d="M15.75,17.08c1.25,0.67,1.69,1.67,1.69,3.31c0,0.97,0.14,26.88-0.37,34.89c-0.73,11.41-1.82,21.46-8.32,36.02"/>
-		<path id="kvg:08146-KaishoVtlst-s2" kvg:type="㇆a" d="M17.92,19.25c1.86-0.06,11.45-2.04,12.83-2.17c2.48-0.22,3.29,0.79,3.29,2.12c0,3.16,0.04,45.17,0.04,63.09c0,14.21-5.24,5.6-6.82,4.12"/>
-		<path id="kvg:08146-KaishoVtlst-s3" kvg:type="㇐a" d="M18.99,38.84c2.5-0.16,4.49-0.53,6.97-0.84c0.68-0.09,1.36-0.17,2.02-0.25"/>
-		<path id="kvg:08146-KaishoVtlst-s4" kvg:type="㇐a" d="M17.6,58.07c2.42-0.04,5.85-0.33,8.26-0.58c0.71-0.07,1.43-0.15,2.14-0.22"/>
+<g id="kvg:StrokePaths_08146-KaishoVtLst" style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;">
+<g id="kvg:08146-KaishoVtLst" kvg:element="腆">
+	<g id="kvg:08146-KaishoVtLst-g1" kvg:element="月" kvg:variant="true" kvg:original="肉" kvg:position="left" kvg:radical="general">
+		<path id="kvg:08146-KaishoVtLst-s1" kvg:type="㇒" d="M15.75,17.08c1.25,0.67,1.69,1.67,1.69,3.31c0,0.97,0.14,26.88-0.37,34.89c-0.73,11.41-1.82,21.46-8.32,36.02"/>
+		<path id="kvg:08146-KaishoVtLst-s2" kvg:type="㇆a" d="M17.92,19.25c1.86-0.06,11.45-2.04,12.83-2.17c2.48-0.22,3.29,0.79,3.29,2.12c0,3.16,0.04,45.17,0.04,63.09c0,14.21-5.24,5.6-6.82,4.12"/>
+		<path id="kvg:08146-KaishoVtLst-s3" kvg:type="㇐a" d="M18.99,38.84c2.5-0.16,4.49-0.53,6.97-0.84c0.68-0.09,1.36-0.17,2.02-0.25"/>
+		<path id="kvg:08146-KaishoVtLst-s4" kvg:type="㇐a" d="M17.6,58.07c2.42-0.04,5.85-0.33,8.26-0.58c0.71-0.07,1.43-0.15,2.14-0.22"/>
 	</g>
-	<g id="kvg:08146-KaishoVtlst-g2" kvg:element="典" kvg:position="right">
-		<g id="kvg:08146-KaishoVtlst-g3" kvg:element="曲" kvg:position="top">
-			<g id="kvg:08146-KaishoVtlst-g4" kvg:element="日" kvg:part="1">
-				<path id="kvg:08146-KaishoVtlst-s5" kvg:type="㇑" d="M45.25,25.92c1.25,0.83,2.13,2.73,2.13,4.05c0,1.32,1.7,36.29,1.7,36.95"/>
-				<path id="kvg:08146-KaishoVtlst-s6" kvg:type="㇕a" d="M47.58,28.25c2.85-0.59,37.09-3.28,39.6-3.63c1.42-0.2,3.11,0.77,2.94,3.08c-0.26,3.54-1.8,21.5-2.54,36.39"/>
+	<g id="kvg:08146-KaishoVtLst-g2" kvg:element="典" kvg:position="right">
+		<g id="kvg:08146-KaishoVtLst-g3" kvg:element="曲" kvg:position="top">
+			<g id="kvg:08146-KaishoVtLst-g4" kvg:element="日" kvg:part="1">
+				<path id="kvg:08146-KaishoVtLst-s5" kvg:type="㇑" d="M45.25,25.92c1.25,0.83,2.13,2.73,2.13,4.05c0,1.32,1.7,36.29,1.7,36.95"/>
+				<path id="kvg:08146-KaishoVtLst-s6" kvg:type="㇕a" d="M47.58,28.25c2.85-0.59,37.09-3.28,39.6-3.63c1.42-0.2,3.11,0.77,2.94,3.08c-0.26,3.54-1.8,21.5-2.54,36.39"/>
 			</g>
-			<g id="kvg:08146-KaishoVtlst-g5" kvg:element="廾" kvg:part="1" kvg:variant="true">
-				<g id="kvg:08146-KaishoVtlst-g6" kvg:element="丿">
-					<g id="kvg:08146-KaishoVtlst-g7" kvg:element="十" kvg:part="1">
-						<path id="kvg:08146-KaishoVtlst-s7" kvg:type="㇐a" d="M48.68,46.05c11.32-0.3,19.89-1.3,28.73-1.98c1.11-0.08,2.18-0.17,3.21-0.24"/>
+			<g id="kvg:08146-KaishoVtLst-g5" kvg:element="廾" kvg:part="1" kvg:variant="true">
+				<g id="kvg:08146-KaishoVtLst-g6" kvg:element="丿">
+					<g id="kvg:08146-KaishoVtLst-g7" kvg:element="十" kvg:part="1">
+						<path id="kvg:08146-KaishoVtLst-s7" kvg:type="㇐a" d="M48.68,46.05c11.32-0.3,19.89-1.3,28.73-1.98c1.11-0.08,2.18-0.17,3.21-0.24"/>
 					</g>
 				</g>
-				<path id="kvg:08146-KaishoVtlst-s8" kvg:type="㇐a" d="M40.08,67.58c1.11,0.32,2.92,0.67,5.33,0.5c8.56-0.59,34.72-3.03,47.83-3.17c1.85-0.02,3.75-0.17,5.67,0.67"/>
-				<g id="kvg:08146-KaishoVtlst-g8" kvg:element="日" kvg:part="2">
-					<g id="kvg:08146-KaishoVtlst-g9" kvg:element="十" kvg:part="2">
-				<path id="kvg:08146-KaishoVtlst-s9" kvg:type="㇑a" d="M58.08,12.42c0.64,0.41,1.97,3.16,1.99,4.01c0.4,18.24,0.84,41.23,1.28,48.9"/>
+				<path id="kvg:08146-KaishoVtLst-s8" kvg:type="㇐a" d="M40.08,67.58c1.11,0.32,2.92,0.67,5.33,0.5c8.56-0.59,34.72-3.03,47.83-3.17c1.85-0.02,3.75-0.17,5.67,0.67"/>
+				<g id="kvg:08146-KaishoVtLst-g8" kvg:element="日" kvg:part="2">
+					<g id="kvg:08146-KaishoVtLst-g9" kvg:element="十" kvg:part="2">
+				<path id="kvg:08146-KaishoVtLst-s9" kvg:type="㇑a" d="M58.08,12.42c0.64,0.41,1.97,3.16,1.99,4.01c0.4,18.24,0.84,41.23,1.28,48.9"/>
 					</g>
 				</g>
-						<path id="kvg:08146-KaishoVtlst-s10" kvg:type="㇑a" d="M74.08,12.08c0.53,0.38,1.67,1.92,1.67,4.17c0,23-0.26,32.55-1,48.5"/>
+						<path id="kvg:08146-KaishoVtLst-s10" kvg:type="㇑a" d="M74.08,12.08c0.53,0.38,1.67,1.92,1.67,4.17c0,23-0.26,32.55-1,48.5"/>
 			</g>
 		</g>
-		<g id="kvg:08146-KaishoVtlst-g10" kvg:element="八" kvg:position="bottom">
-			<g id="kvg:08146-KaishoVtlst-g11" kvg:position="left">
-				<path id="kvg:08146-KaishoVtlst-s11" kvg:type="㇒" d="M58.98,74.06c0.05,0.47,0.1,1.23-0.1,1.91c-1.19,4.02-7.99,12.85-17.31,18.25"/>
+		<g id="kvg:08146-KaishoVtLst-g10" kvg:element="八" kvg:position="bottom">
+			<g id="kvg:08146-KaishoVtLst-g11" kvg:position="left">
+				<path id="kvg:08146-KaishoVtLst-s11" kvg:type="㇒" d="M58.98,74.06c0.05,0.47,0.1,1.23-0.1,1.91c-1.19,4.02-7.99,12.85-17.31,18.25"/>
 			</g>
-			<g id="kvg:08146-KaishoVtlst-g12" kvg:position="right">
-				<path id="kvg:08146-KaishoVtlst-s12" kvg:type="㇏" d="M75.42,74.2c5.96,3.77,15.41,15.51,16.9,21.38"/>
+			<g id="kvg:08146-KaishoVtLst-g12" kvg:position="right">
+				<path id="kvg:08146-KaishoVtLst-s12" kvg:type="㇏" d="M75.42,74.2c5.96,3.77,15.41,15.51,16.9,21.38"/>
 			</g>
 		</g>
 	</g>
 </g>
 </g>
-<g id="kvg:StrokeNumbers_08146-KaishoVtlst" style="font-size:8;fill:#808080">
+<g id="kvg:StrokeNumbers_08146-KaishoVtLst" style="font-size:8;fill:#808080">
 	<text transform="matrix(1 0 0 1 10.25 25.25)">1</text>
 	<text transform="matrix(1 0 0 1 19.25 16.25)">2</text>
 	<text transform="matrix(1 0 0 1 21.25 35.25)">3</text>

--- a/kanji/084d9-KaishoVtLst.svg
+++ b/kanji/084d9-KaishoVtLst.svg
@@ -35,42 +35,42 @@ xmlns:kvg CDATA #FIXED "http://kanjivg.tagaini.net"
 kvg:type CDATA #IMPLIED >
 ]>
 <svg xmlns="http://www.w3.org/2000/svg" width="109" height="109" viewBox="0 0 109 109">
-<g id="kvg:StrokePaths_084d9-Kaisho" style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;">
-<g id="kvg:084d9-Kaisho" kvg:element="蓙">
-	<g id="kvg:084d9-Kaisho-g1" kvg:element="艹" kvg:variant="true" kvg:original="艸" kvg:position="top" kvg:radical="general">
-		<path id="kvg:084d9-Kaisho-s1" kvg:type="㇐" d="M20.5,23.27c1.29,0.53,2.8,0.63,4.1,0.53c11.9-0.96,46.9-3.96,60.62-4.03c2.16-0.01,3.45,0.25,4.53,0.51"/>
-		<path id="kvg:084d9-Kaisho-s2" kvg:type="㇑a" d="M35.25,12.5c1.75,1.43,2.31,1.87,2.5,2.75C39.5,23.5,40,28,40.5,31"/>
-		<path id="kvg:084d9-Kaisho-s3" kvg:type="㇑a" d="M69.25,11.25c1.12,1,1.87,2.52,1.5,4c-1.12,4.5-1.88,9.5-3.5,15.25"/>
+<g id="kvg:StrokePaths_084d9-KaishoVtLst" style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;">
+<g id="kvg:084d9-KaishoVtLst" kvg:element="蓙">
+	<g id="kvg:084d9-KaishoVtLst-g1" kvg:element="艹" kvg:variant="true" kvg:original="艸" kvg:position="top" kvg:radical="general">
+		<path id="kvg:084d9-KaishoVtLst-s1" kvg:type="㇐" d="M20.5,23.27c1.29,0.53,2.8,0.63,4.1,0.53c11.9-0.96,46.9-3.96,60.62-4.03c2.16-0.01,3.45,0.25,4.53,0.51"/>
+		<path id="kvg:084d9-KaishoVtLst-s2" kvg:type="㇑a" d="M35.25,12.5c1.75,1.43,2.31,1.87,2.5,2.75C39.5,23.5,40,28,40.5,31"/>
+		<path id="kvg:084d9-KaishoVtLst-s3" kvg:type="㇑a" d="M69.25,11.25c1.12,1,1.87,2.52,1.5,4c-1.12,4.5-1.88,9.5-3.5,15.25"/>
 	</g>
-	<g id="kvg:084d9-Kaisho-g2" kvg:element="座" kvg:position="bottom">
-		<g id="kvg:084d9-Kaisho-g3" kvg:element="广" kvg:position="tare">
-			<path id="kvg:084d9-Kaisho-s4" kvg:type="㇑a" d="M51.33,26.61c1.91,0.74,5.96,5.55,6.34,7.04"/>
-			<g id="kvg:084d9-Kaisho-g4" kvg:element="厂">
-				<path id="kvg:084d9-Kaisho-s5" kvg:type="㇐" d="M24.23,40.15c1.46,0.52,4.15,0.61,5.61,0.52c15.22-0.87,36.66-2.67,54.06-3.59c2.43-0.13,3.9,0.25,5.12,0.51"/>
-				<path id="kvg:084d9-Kaisho-s6" kvg:type="㇒" d="M27.95,41.32c0.05,1.32,0.1,3.4-0.1,5.29c-1.2,11.14-2.48,38.48-16.79,50.18"/>
+	<g id="kvg:084d9-KaishoVtLst-g2" kvg:element="座" kvg:position="bottom">
+		<g id="kvg:084d9-KaishoVtLst-g3" kvg:element="广" kvg:position="tare">
+			<path id="kvg:084d9-KaishoVtLst-s4" kvg:type="㇑a" d="M51.33,26.61c1.91,0.74,5.96,5.55,6.34,7.04"/>
+			<g id="kvg:084d9-KaishoVtLst-g4" kvg:element="厂">
+				<path id="kvg:084d9-KaishoVtLst-s5" kvg:type="㇐" d="M24.23,40.15c1.46,0.52,4.15,0.61,5.61,0.52c15.22-0.87,36.66-2.67,54.06-3.59c2.43-0.13,3.9,0.25,5.12,0.51"/>
+				<path id="kvg:084d9-KaishoVtLst-s6" kvg:type="㇒" d="M27.95,41.32c0.05,1.32,0.1,3.4-0.1,5.29c-1.2,11.14-2.48,38.48-16.79,50.18"/>
 			</g>
 		</g>
-		<g id="kvg:084d9-Kaisho-g5" kvg:element="坐">
-			<g id="kvg:084d9-Kaisho-g6" kvg:element="从">
-				<g id="kvg:084d9-Kaisho-g7" kvg:element="人" kvg:position="left">
-					<path id="kvg:084d9-Kaisho-s7" kvg:type="㇒" d="M43.88,46.8c0,0.53,0.06,0.97-0.09,1.59c-1.4,5.76-5.6,12.92-11.75,19.28"/>
-					<path id="kvg:084d9-Kaisho-s8" kvg:type="㇏" d="M41.33,56.02c3.61,1.83,8.22,6.68,9.98,11.29"/>
+		<g id="kvg:084d9-KaishoVtLst-g5" kvg:element="坐">
+			<g id="kvg:084d9-KaishoVtLst-g6" kvg:element="从">
+				<g id="kvg:084d9-KaishoVtLst-g7" kvg:element="人" kvg:position="left">
+					<path id="kvg:084d9-KaishoVtLst-s7" kvg:type="㇒" d="M43.88,46.8c0,0.53,0.06,0.97-0.09,1.59c-1.4,5.76-5.6,12.92-11.75,19.28"/>
+					<path id="kvg:084d9-KaishoVtLst-s8" kvg:type="㇏" d="M41.33,56.02c3.61,1.83,8.22,6.68,9.98,11.29"/>
 				</g>
-				<g id="kvg:084d9-Kaisho-g8" kvg:element="人" kvg:position="right">
-					<path id="kvg:084d9-Kaisho-s9" kvg:type="㇒" d="M74.01,44.7c0,0.52,0.08,0.97-0.08,1.55c-1.47,5.07-5.67,14.11-10.67,19.23"/>
-					<path id="kvg:084d9-Kaisho-s10" kvg:type="㇏" d="M73.24,52.97c5.76,3.49,10.18,7.87,13.62,13.16"/>
+				<g id="kvg:084d9-KaishoVtLst-g8" kvg:element="人" kvg:position="right">
+					<path id="kvg:084d9-KaishoVtLst-s9" kvg:type="㇒" d="M74.01,44.7c0,0.52,0.08,0.97-0.08,1.55c-1.47,5.07-5.67,14.11-10.67,19.23"/>
+					<path id="kvg:084d9-KaishoVtLst-s10" kvg:type="㇏" d="M73.24,52.97c5.76,3.49,10.18,7.87,13.62,13.16"/>
 				</g>
 			</g>
-			<g id="kvg:084d9-Kaisho-g9" kvg:element="土">
-				<path id="kvg:084d9-Kaisho-s11" kvg:type="㇐" d="M36.58,78.02c0.9,0.35,2.55,0.44,3.44,0.35c11.54-1.19,28.91-2.75,40.54-3.06c1.5-0.04,2.39,0.17,3.14,0.34"/>
-				<path id="kvg:084d9-Kaisho-s12" kvg:type="㇐" d="M28.16,94.37c1.21,0.43,3.44,0.53,4.65,0.43c15.02-1.21,42.79-2.31,56.22-2.88c2.02-0.08,3.23,0.21,4.25,0.42"/>
-				<path id="kvg:084d9-Kaisho-s13" kvg:type="㇑a" d="M56.06,45.06c0.1,0.23,1.42,1.22,1.42,2.71c0,9.59,0.11,32.43,0.11,45.11"/>
+			<g id="kvg:084d9-KaishoVtLst-g9" kvg:element="土">
+				<path id="kvg:084d9-KaishoVtLst-s11" kvg:type="㇐" d="M36.58,78.02c0.9,0.35,2.55,0.44,3.44,0.35c11.54-1.19,28.91-2.75,40.54-3.06c1.5-0.04,2.39,0.17,3.14,0.34"/>
+				<path id="kvg:084d9-KaishoVtLst-s12" kvg:type="㇐" d="M28.16,94.37c1.21,0.43,3.44,0.53,4.65,0.43c15.02-1.21,42.79-2.31,56.22-2.88c2.02-0.08,3.23,0.21,4.25,0.42"/>
+				<path id="kvg:084d9-KaishoVtLst-s13" kvg:type="㇑a" d="M56.06,45.06c0.1,0.23,1.42,1.22,1.42,2.71c0,9.59,0.11,32.43,0.11,45.11"/>
 			</g>
 		</g>
 	</g>
 </g>
 </g>
-<g id="kvg:StrokeNumbers_084d9-Kaisho" style="font-size:8;fill:#808080">
+<g id="kvg:StrokeNumbers_084d9-KaishoVtLst" style="font-size:8;fill:#808080">
 	<text transform="matrix(1 0 0 1 14.50 23.50)">1</text>
 	<text transform="matrix(1 0 0 1 26.50 12.50)">2</text>
 	<text transform="matrix(1 0 0 1 60.50 11.50)">3</text>

--- a/kanji/084d9-VtLst.svg
+++ b/kanji/084d9-VtLst.svg
@@ -35,42 +35,42 @@ xmlns:kvg CDATA #FIXED "http://kanjivg.tagaini.net"
 kvg:type CDATA #IMPLIED >
 ]>
 <svg xmlns="http://www.w3.org/2000/svg" width="109" height="109" viewBox="0 0 109 109">
-<g id="kvg:StrokePaths_084d9" style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;">
-<g id="kvg:084d9" kvg:element="蓙">
-	<g id="kvg:084d9-g1" kvg:element="艹" kvg:variant="true" kvg:original="艸" kvg:position="top" kvg:radical="general">
-		<path id="kvg:084d9-s1" kvg:type="㇐" d="M20.5,23.27c1.29,0.53,2.8,0.63,4.1,0.53c11.9-0.96,46.9-3.96,60.62-4.03c2.16-0.01,3.45,0.25,4.53,0.51"/>
-		<path id="kvg:084d9-s2" kvg:type="㇑a" d="M35.25,12.5c1.75,1.43,2.31,1.87,2.5,2.75C39.5,23.5,40,28,40.5,31"/>
-		<path id="kvg:084d9-s3" kvg:type="㇑a" d="M69.25,11.25c1.12,1,1.87,2.52,1.5,4c-1.12,4.5-1.88,9.5-3.5,15.25"/>
+<g id="kvg:StrokePaths_084d9-VtLst" style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;">
+<g id="kvg:084d9-VtLst" kvg:element="蓙">
+	<g id="kvg:084d9-VtLst-g1" kvg:element="艹" kvg:variant="true" kvg:original="艸" kvg:position="top" kvg:radical="general">
+		<path id="kvg:084d9-VtLst-s1" kvg:type="㇐" d="M20.5,23.27c1.29,0.53,2.8,0.63,4.1,0.53c11.9-0.96,46.9-3.96,60.62-4.03c2.16-0.01,3.45,0.25,4.53,0.51"/>
+		<path id="kvg:084d9-VtLst-s2" kvg:type="㇑a" d="M35.25,12.5c1.75,1.43,2.31,1.87,2.5,2.75C39.5,23.5,40,28,40.5,31"/>
+		<path id="kvg:084d9-VtLst-s3" kvg:type="㇑a" d="M69.25,11.25c1.12,1,1.87,2.52,1.5,4c-1.12,4.5-1.88,9.5-3.5,15.25"/>
 	</g>
-	<g id="kvg:084d9-g2" kvg:element="座" kvg:position="bottom">
-		<g id="kvg:084d9-g3" kvg:element="广" kvg:position="tare">
-			<path id="kvg:084d9-s4" kvg:type="㇑a" d="M52.75,26.61c0.73,0.37,2.28,2.78,2.42,3.52c0.15,0.74,0.08,3.48-0.07,8.12"/>
-			<g id="kvg:084d9-g4" kvg:element="厂">
-				<path id="kvg:084d9-s5" kvg:type="㇐" d="M24.23,40.15c1.46,0.52,4.15,0.61,5.61,0.52c15.22-0.87,36.66-2.67,54.06-3.59c2.43-0.13,3.9,0.25,5.12,0.51"/>
-				<path id="kvg:084d9-s6" kvg:type="㇒" d="M27.95,41.32c0.05,1.32,0.1,3.4-0.1,5.29c-1.2,11.14-2.48,38.48-16.79,50.18"/>
+	<g id="kvg:084d9-VtLst-g2" kvg:element="座" kvg:position="bottom">
+		<g id="kvg:084d9-VtLst-g3" kvg:element="广" kvg:position="tare">
+			<path id="kvg:084d9-VtLst-s4" kvg:type="㇑a" d="M52.75,26.61c0.73,0.37,2.28,2.78,2.42,3.52c0.15,0.74,0.08,3.48-0.07,8.12"/>
+			<g id="kvg:084d9-VtLst-g4" kvg:element="厂">
+				<path id="kvg:084d9-VtLst-s5" kvg:type="㇐" d="M24.23,40.15c1.46,0.52,4.15,0.61,5.61,0.52c15.22-0.87,36.66-2.67,54.06-3.59c2.43-0.13,3.9,0.25,5.12,0.51"/>
+				<path id="kvg:084d9-VtLst-s6" kvg:type="㇒" d="M27.95,41.32c0.05,1.32,0.1,3.4-0.1,5.29c-1.2,11.14-2.48,38.48-16.79,50.18"/>
 			</g>
 		</g>
-		<g id="kvg:084d9-g5" kvg:element="坐">
-			<g id="kvg:084d9-g6" kvg:element="从">
-				<g id="kvg:084d9-g7" kvg:element="人" kvg:position="left">
-					<path id="kvg:084d9-s7" kvg:type="㇒" d="M43.88,46.8c0,0.53,0.06,0.97-0.09,1.59c-1.4,5.76-5.6,12.92-11.75,19.28"/>
-					<path id="kvg:084d9-s8" kvg:type="㇏" d="M41.33,56.02c3.61,1.83,8.22,6.68,9.98,11.29"/>
+		<g id="kvg:084d9-VtLst-g5" kvg:element="坐">
+			<g id="kvg:084d9-VtLst-g6" kvg:element="从">
+				<g id="kvg:084d9-VtLst-g7" kvg:element="人" kvg:position="left">
+					<path id="kvg:084d9-VtLst-s7" kvg:type="㇒" d="M43.88,46.8c0,0.53,0.06,0.97-0.09,1.59c-1.4,5.76-5.6,12.92-11.75,19.28"/>
+					<path id="kvg:084d9-VtLst-s8" kvg:type="㇏" d="M41.33,56.02c3.61,1.83,8.22,6.68,9.98,11.29"/>
 				</g>
-				<g id="kvg:084d9-g8" kvg:element="人" kvg:position="right">
-					<path id="kvg:084d9-s9" kvg:type="㇒" d="M74.01,44.7c0,0.52,0.08,0.97-0.08,1.55c-1.47,5.07-5.67,14.11-10.67,19.23"/>
-					<path id="kvg:084d9-s10" kvg:type="㇏" d="M73.24,52.97c5.76,3.49,10.18,7.87,13.62,13.16"/>
+				<g id="kvg:084d9-VtLst-g8" kvg:element="人" kvg:position="right">
+					<path id="kvg:084d9-VtLst-s9" kvg:type="㇒" d="M74.01,44.7c0,0.52,0.08,0.97-0.08,1.55c-1.47,5.07-5.67,14.11-10.67,19.23"/>
+					<path id="kvg:084d9-VtLst-s10" kvg:type="㇏" d="M73.24,52.97c5.76,3.49,10.18,7.87,13.62,13.16"/>
 				</g>
 			</g>
-			<g id="kvg:084d9-g9" kvg:element="土">
-				<path id="kvg:084d9-s11" kvg:type="㇐" d="M36.58,78.02c0.9,0.35,2.55,0.44,3.44,0.35c11.54-1.19,28.91-2.75,40.54-3.06c1.5-0.04,2.39,0.17,3.14,0.34"/>
-				<path id="kvg:084d9-s12" kvg:type="㇐" d="M28.16,94.37c1.21,0.43,3.44,0.53,4.65,0.43c15.02-1.21,42.79-2.31,56.22-2.88c2.02-0.08,3.23,0.21,4.25,0.42"/>
-				<path id="kvg:084d9-s13" kvg:type="㇑a" d="M56.06,45.06c0.1,0.23,1.42,1.22,1.42,2.71c0,9.59,0.11,32.43,0.11,45.11"/>
+			<g id="kvg:084d9-VtLst-g9" kvg:element="土">
+				<path id="kvg:084d9-VtLst-s11" kvg:type="㇐" d="M36.58,78.02c0.9,0.35,2.55,0.44,3.44,0.35c11.54-1.19,28.91-2.75,40.54-3.06c1.5-0.04,2.39,0.17,3.14,0.34"/>
+				<path id="kvg:084d9-VtLst-s12" kvg:type="㇐" d="M28.16,94.37c1.21,0.43,3.44,0.53,4.65,0.43c15.02-1.21,42.79-2.31,56.22-2.88c2.02-0.08,3.23,0.21,4.25,0.42"/>
+				<path id="kvg:084d9-VtLst-s13" kvg:type="㇑a" d="M56.06,45.06c0.1,0.23,1.42,1.22,1.42,2.71c0,9.59,0.11,32.43,0.11,45.11"/>
 			</g>
 		</g>
 	</g>
 </g>
 </g>
-<g id="kvg:StrokeNumbers_084d9" style="font-size:8;fill:#808080">
+<g id="kvg:StrokeNumbers_084d9-VtLst" style="font-size:8;fill:#808080">
 	<text transform="matrix(1 0 0 1 14.50 23.50)">1</text>
 	<text transform="matrix(1 0 0 1 26.50 12.50)">2</text>
 	<text transform="matrix(1 0 0 1 60.50 11.50)">3</text>


### PR DESCRIPTION
Fixed automatically using `repair_ids` task from [kanjivg-tools](https://github.com/scriptin/kanjivg-tools).

As for `fill:#000000` property in `style` attributes on root group for strokes, I found out this is intentional, since all reported characters are periods, commas, colons, and semicolons. They all are supposed to be filled, since "strokes" in these files are in fact outlines rather than actual brush strokes.