### PR TITLE
Fix 05099/備

### DIFF
--- a/kanji/05099-Hyougai.svg
+++ b/kanji/05099-Hyougai.svg
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (C) 2009/2010/2011 Ulrich Apel.
+This work is distributed under the conditions of the Creative Commons
+Attribution-Share Alike 3.0 Licence. This means you are free:
+* to Share - to copy, distribute and transmit the work
+* to Remix - to adapt the work
+
+Under the following conditions:
+* Attribution. You must attribute the work by stating your use of KanjiVG in
+  your own copyright header and linking to KanjiVG's website
+  (http://kanjivg.tagaini.net)
+* Share Alike. If you alter, transform, or build upon this work, you may
+  distribute the resulting work only under the same or similar license to this
+  one.
+
+See http://creativecommons.org/licenses/by-sa/3.0/ for more details.
+-->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.0//EN" "http://www.w3.org/TR/2001/REC-SVG-20010904/DTD/svg10.dtd" [
+<!ATTLIST g
+xmlns:kvg CDATA #FIXED "http://kanjivg.tagaini.net"
+kvg:element CDATA #IMPLIED
+kvg:variant CDATA #IMPLIED
+kvg:partial CDATA #IMPLIED
+kvg:original CDATA #IMPLIED
+kvg:part CDATA #IMPLIED
+kvg:number CDATA #IMPLIED
+kvg:tradForm CDATA #IMPLIED
+kvg:radicalForm CDATA #IMPLIED
+kvg:position CDATA #IMPLIED
+kvg:radical CDATA #IMPLIED
+kvg:phon CDATA #IMPLIED >
+<!ATTLIST path
+xmlns:kvg CDATA #FIXED "http://kanjivg.tagaini.net"
+kvg:type CDATA #IMPLIED >
+]>
+<svg xmlns="http://www.w3.org/2000/svg" width="109" height="109" viewBox="0 0 109 109">
+<g id="kvg:StrokePaths_05099-Hyougai" style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;">
+<g id="kvg:05099-Hyougai" kvg:element="備">
+	<g id="kvg:05099-Hyougai-g1" kvg:element="亻" kvg:variant="true" kvg:original="人" kvg:position="left" kvg:radical="general">
+		<path id="kvg:05099-Hyougai-s1" kvg:type="㇒" d="M35.25,15c0.25,2-0.07,3.37-0.87,5.08C29.25,31,23.75,42.5,12,55.79"/>
+		<path id="kvg:05099-Hyougai-s2" kvg:type="㇑" d="M26.78,39.25c0.98,0.98,1.51,2.72,1.51,3.98c0,11.17-0.02,33.73-0.04,45.02c0,3.38-0.01,5.75-0.01,6.5"/>
+	</g>
+	<g id="kvg:05099-Hyougai-g2" kvg:position="right" kvg:phon="備right">
+		<g id="kvg:05099-Hyougai-g3" kvg:element="艹" kvg:variant="true" kvg:original="艸">
+			<path id="kvg:05099-Hyougai-s3" kvg:type="㇐" d="M42.75,24.77c2.01,0.6,4.09,0.42,6.14,0.2c8.95-0.98,24.89-2.7,34.74-3.11c2.3-0.1,4.38-0.23,6.88,0.17"/>
+			<path id="kvg:05099-Hyougai-s4" kvg:type="㇑a" d="M53.92,11.75c0.79,0.79,1.31,2.11,1.4,3c0.94,9.75,1.44,14.75,2.34,22.75"/>
+			<path id="kvg:05099-Hyougai-s5" kvg:type="㇑a" d="M75.35,10.5c0.76,0.76,0.74,2.26,0.65,3c-1,7.75-2,14.75-3.32,23"/>
+		</g>
+		<g id="kvg:05099-Hyougai-g4" kvg:element="厂">
+			<path id="kvg:05099-Hyougai-s6" kvg:type="㇐" d="M40.39,39.55c2.36,0.45,4.57,0.42,6.75,0.27c11.26-0.74,26.75-2.39,39.63-3.4c2.34-0.18,4.48-0.29,6.79,0.2"/>
+			<path id="kvg:05099-Hyougai-s7" kvg:type="㇒" d="M53.58,42.5c0,0.88-0.26,2.05-0.59,2.82c-4.11,9.43-8.49,17.31-17.24,26.47"/>
+		</g>
+		<g id="kvg:05099-Hyougai-g5" kvg:element="用">
+			<path id="kvg:05099-Hyougai-s8" kvg:type="㇑/㇒" d="M49.53,54.65c0.53,0.53,0.82,1.35,0.82,2.11c0,7.78,0.09,25.14,0.09,34.24c0,3,0,4.99,0,5.26"/>
+			<path id="kvg:05099-Hyougai-s9" kvg:type="㇆a" d="M51.3,51.79c7.95-0.79,33.15-3.68,34.67-3.84c2.73-0.3,3.41,0.55,3.41,3.07c0,6.98,0.24,27.93,0.24,39.96c0,9.27-5.33,1.28-6.41,0.76"/>
+			<path id="kvg:05099-Hyougai-s10" kvg:type="㇐a" d="M51.55,64.87c10.32-1.49,29.2-2.87,36.64-3.19"/>
+			<path id="kvg:05099-Hyougai-s11" kvg:type="㇐a" d="M51.71,78.45c9.16-1.2,26.41-2.82,36.45-3.15"/>
+			<path id="kvg:05099-Hyougai-s12" kvg:type="㇑" d="M67.82,52.4c0.7,0.7,1.21,2.1,1.21,3.61c0,3.49-0.05,21.37-0.05,31.25c0,2.96-0.05,5.13-0.08,5.9"/>
+		</g>
+	</g>
+</g>
+</g>
+<g id="kvg:StrokeNumbers_05099-Hyougai" style="font-size:8;fill:#808080">
+	<text transform="matrix(1 0 0 1 27.50 15.50)">1</text>
+	<text transform="matrix(1 0 0 1 20.50 55.50)">2</text>
+	<text transform="matrix(1 0 0 1 42.50 21.50)">3</text>
+	<text transform="matrix(1 0 0 1 45.50 10.50)">4</text>
+	<text transform="matrix(1 0 0 1 65.50 9.50)">5</text>
+	<text transform="matrix(1 0 0 1 38.25 36.50)">6</text>
+	<text transform="matrix(1 0 0 1 44.25 50.83)">7</text>
+	<text transform="matrix(1 0 0 1 43.50 72.50)">8</text>
+	<text transform="matrix(1 0 0 1 59.50 47.50)">9</text>
+	<text transform="matrix(1 0 0 1 52.50 61.50)">10</text>
+	<text transform="matrix(1 0 0 1 53.35 74.50)">11</text>
+	<text transform="matrix(1 0 0 1 59.50 58.50)">12</text>
+</g>
+</svg>

--- a/kanji/05099-HyougaiKaisho.svg
+++ b/kanji/05099-HyougaiKaisho.svg
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (C) 2009/2010/2011 Ulrich Apel.
+This work is distributed under the conditions of the Creative Commons
+Attribution-Share Alike 3.0 Licence. This means you are free:
+* to Share - to copy, distribute and transmit the work
+* to Remix - to adapt the work
+
+Under the following conditions:
+* Attribution. You must attribute the work by stating your use of KanjiVG in
+  your own copyright header and linking to KanjiVG's website
+  (http://kanjivg.tagaini.net)
+* Share Alike. If you alter, transform, or build upon this work, you may
+  distribute the resulting work only under the same or similar license to this
+  one.
+
+See http://creativecommons.org/licenses/by-sa/3.0/ for more details.
+-->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.0//EN" "http://www.w3.org/TR/2001/REC-SVG-20010904/DTD/svg10.dtd" [
+<!ATTLIST g
+xmlns:kvg CDATA #FIXED "http://kanjivg.tagaini.net"
+kvg:element CDATA #IMPLIED
+kvg:variant CDATA #IMPLIED
+kvg:partial CDATA #IMPLIED
+kvg:original CDATA #IMPLIED
+kvg:part CDATA #IMPLIED
+kvg:number CDATA #IMPLIED
+kvg:tradForm CDATA #IMPLIED
+kvg:radicalForm CDATA #IMPLIED
+kvg:position CDATA #IMPLIED
+kvg:radical CDATA #IMPLIED
+kvg:phon CDATA #IMPLIED >
+<!ATTLIST path
+xmlns:kvg CDATA #FIXED "http://kanjivg.tagaini.net"
+kvg:type CDATA #IMPLIED >
+]>
+<svg xmlns="http://www.w3.org/2000/svg" width="109" height="109" viewBox="0 0 109 109">
+<g id="kvg:StrokePaths_05099-HyougaiKaisho" style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;">
+<g id="kvg:05099-HyougaiKaisho" kvg:element="備">
+	<g id="kvg:05099-HyougaiKaisho-g1" kvg:element="亻" kvg:variant="true" kvg:original="人" kvg:position="left" kvg:radical="general">
+		<path id="kvg:05099-HyougaiKaisho-s1" kvg:type="㇒" d="M35.25,15c0.25,2-0.07,4.62-0.87,6.33C29.25,32.25,22.75,42.5,11,55.79"/>
+		<path id="kvg:05099-HyougaiKaisho-s2" kvg:type="㇑" d="M27.03,39.5c0.59,0.61,0.7,1.97,0.76,3.23c0.56,11.77-0.52,44.29-0.04,51.52"/>
+	</g>
+	<g id="kvg:05099-HyougaiKaisho-g2" kvg:position="right">
+		<g id="kvg:05099-HyougaiKaisho-g3" kvg:element="艹" kvg:variant="true" kvg:original="艸">
+			<path id="kvg:05099-HyougaiKaisho-s3" kvg:type="㇐" d="M42.75,24.77c0.98,0.53,2.12,0.63,3.11,0.53c9.02-0.96,30.06-3.46,40.46-3.53c1.64-0.01,2.62,0.25,3.44,0.51"/>
+			<path id="kvg:05099-HyougaiKaisho-s4" kvg:type="㇑a" d="M53.42,12c1.33,1.43,1.81,1.86,1.9,2.75c0.94,9.75,1.44,14.75,2.34,22.75"/>
+			<path id="kvg:05099-HyougaiKaisho-s5" kvg:type="㇑a" d="M75.1,10.75c0.4,0.75,0.99,2.01,0.9,2.75c-1,7.75-2,13.75-3.32,22"/>
+		</g>
+		<g id="kvg:05099-HyougaiKaisho-g4" kvg:element="厂">
+			<path id="kvg:05099-HyougaiKaisho-s6" kvg:type="㇐" d="M40.39,39.55c1.17,0.42,3.3,0.48,4.47,0.42c12.13-0.7,30.39-2.71,44.61-3.75c1.94-0.14,3.11,0.2,4.08,0.41"/>
+			<path id="kvg:05099-HyougaiKaisho-s7" kvg:type="㇒" d="M53.33,42c0.05,0.7,0.18,2.02-0.09,2.82c-3.44,9.9-8.52,18.99-17.49,26.97"/>
+		</g>
+		<g id="kvg:05099-HyougaiKaisho-g5" kvg:element="用">
+			<path id="kvg:05099-HyougaiKaisho-s8" kvg:type="㇑/㇒" d="M50.28,52.15c0.17,0.59,0.17,42.77,0.17,44.11"/>
+			<path id="kvg:05099-HyougaiKaisho-s9" kvg:type="㇆a" d="M50.8,52.04c5.74-0.25,33.9-3.68,35.42-3.84c2.73-0.3,3.75,1.93,3.41,2.82c-0.33,0.86-0.51,27.68-0.51,39.71c0,9.27-5.33,1.28-6.41,0.76"/>
+			<path id="kvg:05099-HyougaiKaisho-s10" kvg:type="㇐a" d="M50.8,64.62c8.47-0.58,16.92-1.4,25.38-2.12c0.93-0.08,1.84-0.16,2.73-0.24"/>
+			<path id="kvg:05099-HyougaiKaisho-s11" kvg:type="㇐a" d="M50.96,78.2c8.21-0.66,16.4-1.44,24.61-2.14c0.97-0.08,1.92-0.16,2.84-0.24"/>
+			<path id="kvg:05099-HyougaiKaisho-s12" kvg:type="㇑" d="M68.07,52.65c0.68,0.29,1.08,1.29,1.21,1.86c0.13,0.57,0,35.07-0.14,38.65"/>
+		</g>
+	</g>
+</g>
+</g>
+<g id="kvg:StrokeNumbers_05099-HyougaiKaisho" style="font-size:8;fill:#808080">
+	<text transform="matrix(1 0 0 1 27.50 15.50)">1</text>
+	<text transform="matrix(1 0 0 1 20.50 55.50)">2</text>
+	<text transform="matrix(1 0 0 1 42.50 21.50)">3</text>
+	<text transform="matrix(1 0 0 1 45.50 10.50)">4</text>
+	<text transform="matrix(1 0 0 1 65.50 9.50)">5</text>
+	<text transform="matrix(1 0 0 1 38.25 36.50)">6</text>
+	<text transform="matrix(1 0 0 1 44.25 50.83)">7</text>
+	<text transform="matrix(1 0 0 1 43.50 72.50)">8</text>
+	<text transform="matrix(1 0 0 1 59.50 47.50)">9</text>
+	<text transform="matrix(1 0 0 1 52.50 61.50)">10</text>
+	<text transform="matrix(1 0 0 1 53.35 74.50)">11</text>
+	<text transform="matrix(1 0 0 1 59.50 58.50)">12</text>
+</g>
+</svg>

--- a/kanji/05099-Kaisho.svg
+++ b/kanji/05099-Kaisho.svg
@@ -49,7 +49,7 @@ kvg:type CDATA #IMPLIED >
 		</g>
 		<g id="kvg:05099-Kaisho-g4" kvg:element="厂">
 			<path id="kvg:05099-Kaisho-s6" kvg:type="㇐" d="M40.39,39.55c1.17,0.42,3.3,0.48,4.47,0.42c12.13-0.7,30.39-2.71,44.61-3.75c1.94-0.14,3.11,0.2,4.08,0.41"/>
-			<path id="kvg:05099-Kaisho-s7" kvg:type="㇒" d="M53.33,42c0.05,0.7,0.18,2.02-0.09,2.82c-3.44,9.9-8.52,18.99-17.49,26.97"/>
+			<path id="kvg:05099-Kaisho-s7" kvg:type="㇒" d="m 42.717457,41.626002 c 0,0.88 -0.26,1.925143 -0.340286,3.569141 -0.489153,15.29827 -1.123448,36.91252 -9.374021,49.693368"/>
 		</g>
 		<g id="kvg:05099-Kaisho-g5" kvg:element="用">
 			<path id="kvg:05099-Kaisho-s8" kvg:type="㇑/㇒" d="M50.28,52.15c0.17,0.59,0.17,42.77,0.17,44.11"/>
@@ -68,11 +68,11 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 45.50 10.50)">4</text>
 	<text transform="matrix(1 0 0 1 65.50 9.50)">5</text>
 	<text transform="matrix(1 0 0 1 38.25 36.50)">6</text>
-	<text transform="matrix(1 0 0 1 44.25 50.83)">7</text>
-	<text transform="matrix(1 0 0 1 43.50 72.50)">8</text>
-	<text transform="matrix(1 0 0 1 59.50 47.50)">9</text>
+	<text transform="matrix(1 0 0 1 33.51 51.95)">7</text>
+	<text transform="matrix(1 0 0 1 42.50 64.76)">8</text>
+	<text transform="matrix(1 0 0 1 48.51 50.00)">9</text>
 	<text transform="matrix(1 0 0 1 52.50 61.50)">10</text>
 	<text transform="matrix(1 0 0 1 53.35 74.50)">11</text>
-	<text transform="matrix(1 0 0 1 59.50 58.50)">12</text>
+	<text transform="matrix(1 0 0 1 67.37 59.87)">12</text>
 </g>
 </svg>

--- a/kanji/05099.svg
+++ b/kanji/05099.svg
@@ -49,7 +49,7 @@ kvg:type CDATA #IMPLIED >
 		</g>
 		<g id="kvg:05099-g4" kvg:element="厂">
 			<path id="kvg:05099-s6" kvg:type="㇐" d="M40.39,39.55c2.36,0.45,4.57,0.42,6.75,0.27c11.26-0.74,26.75-2.39,39.63-3.4c2.34-0.18,4.48-0.29,6.79,0.2"/>
-			<path id="kvg:05099-s7" kvg:type="㇒" d="M53.58,42.5c0,0.88-0.26,2.05-0.59,2.82c-4.11,9.43-8.49,17.31-17.24,26.47"/>
+			<path id="kvg:05099-s7" kvg:type="㇒" d="m 42.717457,41.626002 c 0,0.88 -0.26,1.925143 -0.340286,3.569141 -0.489153,15.29827 -1.123448,36.91252 -9.374021,49.693368"/>
 		</g>
 		<g id="kvg:05099-g5" kvg:element="用">
 			<path id="kvg:05099-s8" kvg:type="㇑/㇒" d="M49.53,54.65c0.53,0.53,0.82,1.35,0.82,2.11c0,7.78,0.09,25.14,0.09,34.24c0,3,0,4.99,0,5.26"/>
@@ -68,11 +68,11 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 45.50 10.50)">4</text>
 	<text transform="matrix(1 0 0 1 65.50 9.50)">5</text>
 	<text transform="matrix(1 0 0 1 38.25 36.50)">6</text>
-	<text transform="matrix(1 0 0 1 44.25 50.83)">7</text>
-	<text transform="matrix(1 0 0 1 43.50 72.50)">8</text>
-	<text transform="matrix(1 0 0 1 59.50 47.50)">9</text>
+	<text transform="matrix(1 0 0 1 33.51 51.95)">7</text>
+	<text transform="matrix(1 0 0 1 42.50 64.76)">8</text>
+	<text transform="matrix(1 0 0 1 48.51 50.00)">9</text>
 	<text transform="matrix(1 0 0 1 52.50 61.50)">10</text>
 	<text transform="matrix(1 0 0 1 53.35 74.50)">11</text>
-	<text transform="matrix(1 0 0 1 59.50 58.50)">12</text>
+	<text transform="matrix(1 0 0 1 67.37 59.87)">12</text>
 </g>
 </svg>


### PR DESCRIPTION
This changes 備 to the more common version with an almost vertical stroke 7.
I kept the old version as that seems to be allowed.
This is a fix for #157