### PR TITLE
Remove artefacts from 㐮 and change element

### DIFF
--- a/kanji/058cc-Kaisho.svg
+++ b/kanji/058cc-Kaisho.svg
@@ -42,41 +42,33 @@ kvg:type CDATA #IMPLIED >
 		<path id="kvg:058cc-Kaisho-s2" kvg:type="㇑a" d="M25.37,21c1.09,0.5,1.96,2.23,1.96,3.25c0,7.25,0.03,30.25,0.03,41"/>
 		<path id="kvg:058cc-Kaisho-s3" kvg:type="㇀/㇐" d="M12.25,74.61c0.62,1.14,1.87,1.75,3.74,0.25c5.2-4.19,14.56-11.67,19.76-15.85"/>
 	</g>
-	<g id="kvg:058cc-Kaisho-g2" kvg:element="襄" kvg:variant="true" kvg:position="right">
+	<g id="kvg:058cc-Kaisho-g2" kvg:element="㐮" kvg:variant="true" kvg:original="襄" kvg:position="right">
 		<g id="kvg:058cc-Kaisho-g3" kvg:element="六" kvg:variant="true">
-			<g id="kvg:058cc-Kaisho-g4" kvg:element="衣" kvg:part="1">
-				<g id="kvg:058cc-Kaisho-g5" kvg:element="亠" kvg:position="top">
-					<path id="kvg:058cc-Kaisho-s4" kvg:type="㇑a" d="M61.36,12.75c1.82,0.83,4.04,3.02,4.82,5.68"/>
-					<path id="kvg:058cc-Kaisho-s5" kvg:type="㇐" d="M40.62,25.35c1.24,0.25,2.34,0.51,3.77,0.34c8.52-1.03,32.28-4.36,42.2-4.86c1.46-0.07,2.21,0.03,3.29,0.44"/>
-				</g>
+			<g id="kvg:058cc-Kaisho-g4" kvg:element="亠" kvg:position="top">
+				<path id="kvg:058cc-Kaisho-s4" kvg:type="㇑a" d="M61.36,12.75c1.82,0.83,4.04,3.02,4.82,5.68"/>
+				<path id="kvg:058cc-Kaisho-s5" kvg:type="㇐" d="M40.62,25.35c1.24,0.25,2.34,0.51,3.77,0.34c8.52-1.03,32.28-4.36,42.2-4.86c1.46-0.07,2.21,0.03,3.29,0.44"/>
 			</g>
-			<g id="kvg:058cc-Kaisho-g6" kvg:position="left">
-				<g id="kvg:058cc-Kaisho-g7" kvg:element="八">
-					<g id="kvg:058cc-Kaisho-g8" kvg:element="口" kvg:variant="true">
-						<path id="kvg:058cc-Kaisho-s6" kvg:type="㇒" d="M54.77,28.14c0.03,0.24,0.07,0.61-0.07,0.95c-0.83,2.01-5.61,6.42-12.14,9.12"/>
-					</g>
-				</g>
-				<g id="kvg:058cc-Kaisho-g9" kvg:element="口" kvg:variant="true" kvg:position="right">
-					<path id="kvg:058cc-Kaisho-s7" kvg:type="㇔" d="M74.52,27.08c4.34,1.35,11.21,5.54,12.29,7.63"/>
-				</g>
+			<g id="kvg:058cc-Kaisho-g5" kvg:element="八">
+				<path id="kvg:058cc-Kaisho-s6" kvg:type="㇒" d="M54.77,28.14c0.03,0.24,0.07,0.61-0.07,0.95c-0.83,2.01-5.61,6.42-12.14,9.12"/>
+				<path id="kvg:058cc-Kaisho-s7" kvg:type="㇔" d="M74.52,27.08c4.34,1.35,11.21,5.54,12.29,7.63"/>
 			</g>
 		</g>
-		<g id="kvg:058cc-Kaisho-g10" kvg:element="三" kvg:part="1">
-			<g id="kvg:058cc-Kaisho-g11" kvg:element="一" kvg:position="top">
+		<g id="kvg:058cc-Kaisho-g6" kvg:element="三" kvg:part="1">
+			<g id="kvg:058cc-Kaisho-g7" kvg:element="一" kvg:position="top">
 				<path id="kvg:058cc-Kaisho-s8" kvg:type="㇐" d="M46.75,43.52c0.71,0.29,3.52,0.35,4.24,0.29c6.51-0.56,20.76-3.81,27.77-4.45c1.18-0.11,1.9,0.14,2.5,0.28"/>
 			</g>
 		</g>
 		<path id="kvg:058cc-Kaisho-s9" kvg:type="㇑" d="M54.87,37.75c1.09,0.5,1.74,2.25,1.96,3.25c0.22,1,1,16.25,0.78,22.5"/>
 		<path id="kvg:058cc-Kaisho-s10" kvg:type="㇑" d="M72.37,34.25c0.88,1,1.72,2.24,1.46,3.75C72.5,45.75,72,52.5,71,61"/>
-		<g id="kvg:058cc-Kaisho-g12" kvg:element="三" kvg:part="1" kvg:position="bottom">
-			<g id="kvg:058cc-Kaisho-g13" kvg:element="一">
+		<g id="kvg:058cc-Kaisho-g8" kvg:element="三" kvg:part="1" kvg:position="bottom">
+			<g id="kvg:058cc-Kaisho-g9" kvg:element="一">
 				<path id="kvg:058cc-Kaisho-s11" kvg:type="㇐" d="M46.75,53.52c0.71,0.29,3.52,0.35,4.24,0.29c6.51-0.56,20.76-2.81,27.77-3.45c1.18-0.11,1.9,0.14,2.5,0.28"/>
 			</g>
-			<g id="kvg:058cc-Kaisho-g14" kvg:element="一">
+			<g id="kvg:058cc-Kaisho-g10" kvg:element="一">
 				<path id="kvg:058cc-Kaisho-s12" kvg:type="㇐" d="M38.25,64.89c0.94,0.38,2.66,0.42,3.6,0.38c7.4-0.27,42.57-5.23,47.11-4.88c1.56,0.12,2.5,0.18,3.29,0.37"/>
 			</g>
 		</g>
-		<g id="kvg:058cc-Kaisho-g15" kvg:element="衣" kvg:part="2" kvg:position="bottom">
+		<g id="kvg:058cc-Kaisho-g11" kvg:element="𧘇" kvg:position="bottom">
 			<path id="kvg:058cc-Kaisho-s13" kvg:type="㇒" d="M58.53,64.39c0.06,0.55,0.24,1.46-0.12,2.2c-2.34,4.78-9.95,13.49-21.65,21.02"/>
 			<path id="kvg:058cc-Kaisho-s14" kvg:type="㇙" d="M53.09,77.45c0.32,0.35,0.66,0.7,0.66,1.31c-0.02,7.77-0.21,12.16-0.21,13.47s0.78,2.06,1.77,1.08c0.99-0.99,10.5-8.79,11.82-9.77"/>
 			<path id="kvg:058cc-Kaisho-s15" kvg:type="㇒" d="M79.64,63.69c0.02,0.26,0.25,1.26,0.11,1.61c-0.89,2.16-3.68,5.24-8.22,9.53"/>

--- a/kanji/058cc-KaishoVtLst.svg
+++ b/kanji/058cc-KaishoVtLst.svg
@@ -42,41 +42,33 @@ kvg:type CDATA #IMPLIED >
 		<path id="kvg:058cc-KaishoVtLst-s2" kvg:type="㇑a" d="M25.37,21c1.09,0.5,1.96,2.23,1.96,3.25c0,7.25,0.03,30.25,0.03,41"/>
 		<path id="kvg:058cc-KaishoVtLst-s3" kvg:type="㇀/㇐" d="M12.25,74.61c0.62,1.14,1.87,1.75,3.74,0.25c5.2-4.19,14.56-11.67,19.76-15.85"/>
 	</g>
-	<g id="kvg:058cc-KaishoVtLst-g2" kvg:element="襄" kvg:variant="true" kvg:position="right">
+	<g id="kvg:058cc-KaishoVtLst-g2" kvg:element="㐮" kvg:variant="true" kvg:original="襄" kvg:position="right">
 		<g id="kvg:058cc-KaishoVtLst-g3" kvg:element="六" kvg:variant="true">
-			<g id="kvg:058cc-KaishoVtLst-g4" kvg:element="衣" kvg:part="1">
-				<g id="kvg:058cc-KaishoVtLst-g5" kvg:element="亠" kvg:position="top">
-					<path id="kvg:058cc-KaishoVtLst-s4" kvg:type="㇑a" d="M61.36,12.75c1.82,0.83,4.04,3.02,4.82,5.68"/>
-					<path id="kvg:058cc-KaishoVtLst-s5" kvg:type="㇐" d="M40.62,25.35c1.24,0.25,2.34,0.51,3.77,0.34c8.52-1.03,32.28-4.36,42.2-4.86c1.46-0.07,2.21,0.03,3.29,0.44"/>
-				</g>
+			<g id="kvg:058cc-KaishoVtLst-g4" kvg:element="亠" kvg:position="top">
+				<path id="kvg:058cc-KaishoVtLst-s4" kvg:type="㇑a" d="M61.36,12.75c1.82,0.83,4.04,3.02,4.82,5.68"/>
+				<path id="kvg:058cc-KaishoVtLst-s5" kvg:type="㇐" d="M40.62,25.35c1.24,0.25,2.34,0.51,3.77,0.34c8.52-1.03,32.28-4.36,42.2-4.86c1.46-0.07,2.21,0.03,3.29,0.44"/>
 			</g>
-			<g id="kvg:058cc-KaishoVtLst-g6" kvg:position="left">
-				<g id="kvg:058cc-KaishoVtLst-g7" kvg:element="八">
-					<g id="kvg:058cc-KaishoVtLst-g8" kvg:element="口" kvg:variant="true">
-						<path id="kvg:058cc-KaishoVtLst-s6" kvg:type="㇒" d="M54.77,28.14c0.03,0.24,0.07,0.61-0.07,0.95c-0.83,2.01-5.61,6.42-12.14,9.12"/>
-					</g>
-				</g>
-				<g id="kvg:058cc-KaishoVtLst-g9" kvg:element="口" kvg:variant="true" kvg:position="right">
-					<path id="kvg:058cc-KaishoVtLst-s7" kvg:type="㇔" d="M74.52,27.08c4.34,1.35,11.21,5.54,12.29,7.63"/>
-				</g>
+			<g id="kvg:058cc-KaishoVtLst-g5" kvg:element="八">
+				<path id="kvg:058cc-KaishoVtLst-s6" kvg:type="㇒" d="M54.77,28.14c0.03,0.24,0.07,0.61-0.07,0.95c-0.83,2.01-5.61,6.42-12.14,9.12"/>
+				<path id="kvg:058cc-KaishoVtLst-s7" kvg:type="㇔" d="M74.52,27.08c4.34,1.35,11.21,5.54,12.29,7.63"/>
 			</g>
 		</g>
-		<g id="kvg:058cc-KaishoVtLst-g10" kvg:element="三" kvg:part="1">
-			<g id="kvg:058cc-KaishoVtLst-g11" kvg:element="一" kvg:position="top">
+		<g id="kvg:058cc-KaishoVtLst-g6" kvg:element="三" kvg:part="1">
+			<g id="kvg:058cc-KaishoVtLst-g7" kvg:element="一" kvg:position="top">
 				<path id="kvg:058cc-KaishoVtLst-s8" kvg:type="㇐" d="M46.75,43.52c0.71,0.29,3.52,0.35,4.24,0.29c6.51-0.56,20.76-3.81,27.77-4.45c1.18-0.11,1.9,0.14,2.5,0.28"/>
 			</g>
 		</g>
-		<g id="kvg:058cc-KaishoVtLst-g12" kvg:element="三" kvg:part="1" kvg:position="bottom">
-			<g id="kvg:058cc-KaishoVtLst-g13" kvg:element="一">
+		<g id="kvg:058cc-KaishoVtLst-g8" kvg:element="三" kvg:part="1" kvg:position="bottom">
+			<g id="kvg:058cc-KaishoVtLst-g9" kvg:element="一">
 				<path id="kvg:058cc-KaishoVtLst-s9" kvg:type="㇐" d="M46.75,53.52c0.71,0.29,3.52,0.35,4.24,0.29c6.51-0.56,20.76-2.81,27.77-3.45c1.18-0.11,1.9,0.14,2.5,0.28"/>
 			</g>
-			<g id="kvg:058cc-KaishoVtLst-g14" kvg:element="一">
+			<g id="kvg:058cc-KaishoVtLst-g10" kvg:element="一">
 				<path id="kvg:058cc-KaishoVtLst-s10" kvg:type="㇐" d="M38.25,64.89c0.94,0.38,2.66,0.42,3.6,0.38c7.4-0.27,42.57-5.23,47.11-4.88c1.56,0.12,2.5,0.18,3.29,0.37"/>
 			</g>
 			<path id="kvg:058cc-KaishoVtLst-s11" kvg:type="㇑" d="M54.87,37.75c1.09,0.5,1.74,2.25,1.96,3.25c0.22,1,1,16.25,0.78,22.5"/>
 			<path id="kvg:058cc-KaishoVtLst-s12" kvg:type="㇑" d="M72.37,34.25c0.88,1,1.72,2.24,1.46,3.75C72.5,45.75,72,52.5,71,61"/>
 		</g>
-		<g id="kvg:058cc-KaishoVtLst-g15" kvg:element="衣" kvg:part="2" kvg:position="bottom">
+		<g id="kvg:058cc-KaishoVtLst-g11" kvg:element="𧘇" kvg:position="bottom">
 			<path id="kvg:058cc-KaishoVtLst-s13" kvg:type="㇒" d="M58.53,64.39c0.06,0.55,0.24,1.46-0.12,2.2c-2.34,4.78-9.95,13.49-21.65,21.02"/>
 			<path id="kvg:058cc-KaishoVtLst-s14" kvg:type="㇙" d="M79.64,63.69c0.02,0.26,0.25,1.26,0.11,1.61c-0.89,2.16-3.68,5.24-8.22,9.53"/>
 			<path id="kvg:058cc-KaishoVtLst-s15" kvg:type="㇒" d="M59.87,68.14c1.54,0.67,4.01,2.57,4.44,2.86c6.31,4.24,21.65,15.06,25.91,17.56c1.6,0.94,2.98,1.34,4.58,1.61"/>

--- a/kanji/058cc.svg
+++ b/kanji/058cc.svg
@@ -42,41 +42,33 @@ kvg:type CDATA #IMPLIED >
 		<path id="kvg:058cc-s2" kvg:type="㇑a" d="M25.87,21c0.88,0.88,1.21,2.12,1.21,3.5c0,7.25,0.03,29.75,0.03,40.5"/>
 		<path id="kvg:058cc-s3" kvg:type="㇀/㇐" d="M12,74.86c1.12,0.77,2.88,0.77,4.24-0.25c5.35-3.99,14.31-11.42,19.51-15.6"/>
 	</g>
-	<g id="kvg:058cc-g2" kvg:element="襄" kvg:variant="true" kvg:position="right" kvg:phon="襄V">
+	<g id="kvg:058cc-g2" kvg:element="㐮" kvg:variant="true" kvg:original="襄" kvg:position="right" kvg:phon="襄V">
 		<g id="kvg:058cc-g3" kvg:element="六" kvg:variant="true">
-			<g id="kvg:058cc-g4" kvg:element="衣" kvg:part="1">
-				<g id="kvg:058cc-g5" kvg:element="亠" kvg:position="top">
-					<path id="kvg:058cc-s4" kvg:type="㇑a" d="M63.39,13.25c1.05,1.05,1.35,2.12,1.35,3.59c0,1.16-0.09,3.78-0.09,4.93"/>
-					<path id="kvg:058cc-s5" kvg:type="㇐" d="M40.37,25.1c2.57,0.51,5.3,0.41,7.89,0.07c9.42-1.21,25.76-3.67,35.24-4.4c2.04-0.16,4.12-0.14,6.38,0.25"/>
-				</g>
+			<g id="kvg:058cc-g4" kvg:element="亠" kvg:position="top">
+				<path id="kvg:058cc-s4" kvg:type="㇑a" d="M63.39,13.25c1.05,1.05,1.35,2.12,1.35,3.59c0,1.16-0.09,3.78-0.09,4.93"/>
+				<path id="kvg:058cc-s5" kvg:type="㇐" d="M40.37,25.1c2.57,0.51,5.3,0.41,7.89,0.07c9.42-1.21,25.76-3.67,35.24-4.4c2.04-0.16,4.12-0.14,6.38,0.25"/>
 			</g>
-			<g id="kvg:058cc-g6" kvg:position="left">
-				<g id="kvg:058cc-g7" kvg:element="八">
-					<g id="kvg:058cc-g8" kvg:element="口" kvg:variant="true">
-						<path id="kvg:058cc-s6" kvg:type="㇒" d="M54.52,27.64c0.04,0.25,0.07,0.64-0.07,1c-0.79,1.94-5.03,6.02-10.95,8.86"/>
-					</g>
-				</g>
-				<g id="kvg:058cc-g9" kvg:element="口" kvg:variant="true" kvg:position="right">
-					<path id="kvg:058cc-s7" kvg:type="㇔" d="M74.77,27.33c4.34,1.35,10.96,5.29,12.04,7.38"/>
-				</g>
+			<g id="kvg:058cc-g5" kvg:element="八">
+				<path id="kvg:058cc-s6" kvg:type="㇒" d="M54.52,27.64c0.04,0.25,0.07,0.64-0.07,1c-0.79,1.94-5.03,6.02-10.95,8.86"/>
+				<path id="kvg:058cc-s7" kvg:type="㇔" d="M74.77,27.33c4.34,1.35,10.96,5.29,12.04,7.38"/>
 			</g>
 		</g>
-		<g id="kvg:058cc-g10" kvg:element="三" kvg:part="1">
-			<g id="kvg:058cc-g11" kvg:element="一" kvg:position="top">
+		<g id="kvg:058cc-g6" kvg:element="三" kvg:part="1">
+			<g id="kvg:058cc-g7" kvg:element="一" kvg:position="top">
 				<path id="kvg:058cc-s8" kvg:type="㇐" d="M47.25,43.02c1.63,0.66,4.52,0.48,6.27,0.27c6.75-0.85,16.44-2.5,24.35-3.53c1.19-0.16,2.44-0.4,3.63-0.11"/>
 			</g>
 		</g>
 		<path id="kvg:058cc-s9" kvg:type="㇑a" d="M55.87,38c1,1,1.21,2.62,1.21,4c0,1.02,0.42,10.75,0.78,20.25"/>
 		<path id="kvg:058cc-s10" kvg:type="㇑a" d="M72.62,34c0.88,1,1.17,2.48,0.96,4c-1.33,9.5-1.83,14.25-2.83,22.75"/>
-		<g id="kvg:058cc-g12" kvg:element="三" kvg:part="1" kvg:position="bottom">
-			<g id="kvg:058cc-g13" kvg:element="一">
+		<g id="kvg:058cc-g8" kvg:element="三" kvg:part="1" kvg:position="bottom">
+			<g id="kvg:058cc-g9" kvg:element="一">
 				<path id="kvg:058cc-s11" kvg:type="㇐" d="M47.25,53.27c1.89,0.77,4.32,0.55,6.27,0.34c6.54-0.71,17.29-2.41,23.85-3.11c1.36-0.15,2.79-0.43,4.12-0.1"/>
 			</g>
-			<g id="kvg:058cc-g14" kvg:element="一">
+			<g id="kvg:058cc-g10" kvg:element="一">
 				<path id="kvg:058cc-s12" kvg:type="㇐" d="M39,64.64c2.1,0.85,4.96,0.32,7.11,0.12c9.55-0.89,30.31-3.79,39.26-4.48c2.34-0.18,4.82-0.34,7.12,0.22"/>
 			</g>
 		</g>
-		<g id="kvg:058cc-g15" kvg:element="衣" kvg:part="2" kvg:position="bottom">
+		<g id="kvg:058cc-g11" kvg:element="𧘇" kvg:position="bottom">
 			<path id="kvg:058cc-s13" kvg:type="㇒" d="M58.28,65.64c0.06,0.55,0.11,1.52-0.37,2.2c-4.03,5.66-9.2,11.24-20.9,18.77"/>
 			<path id="kvg:058cc-s14" kvg:type="㇙" d="M53.59,77.45c0.67,0.75,0.66,1.32,0.66,2.3c-0.01,7.15-0.12,11.62-0.12,12.88c0,1.31,0.88,1.61,1.94,0.68c4.19-3.68,9.5-9.04,10.82-10.02"/>
 			<path id="kvg:058cc-s15" kvg:type="㇒" d="M79.64,63.94c0.07,0.74,0.04,1.52-0.39,2.13c-2.13,3.06-2.79,3.55-6.98,7.5"/>

--- a/kanji/05b22-Kaisho.svg
+++ b/kanji/05b22-Kaisho.svg
@@ -42,41 +42,33 @@ kvg:type CDATA #IMPLIED >
 		<path id="kvg:05b22-Kaisho-s2" kvg:type="㇒" d="M36.89,38.41c0.07,1.21,0.12,4.16-0.14,5.92c-2.13,14.21-8.29,34.35-23.54,44.92"/>
 		<path id="kvg:05b22-Kaisho-s3" kvg:type="㇀/㇐" d="M12,49.22c0.62,0.99,1.94,1.2,3.59,0.96C17.36,49.93,31,46,40,43.62"/>
 	</g>
-	<g id="kvg:05b22-Kaisho-g2" kvg:element="襄" kvg:variant="true" kvg:position="right">
+	<g id="kvg:05b22-Kaisho-g2" kvg:element="㐮" kvg:variant="true" kvg:original="襄" kvg:position="right">
 		<g id="kvg:05b22-Kaisho-g3" kvg:element="六" kvg:variant="true">
-			<g id="kvg:05b22-Kaisho-g4" kvg:element="衣" kvg:part="1">
-				<g id="kvg:05b22-Kaisho-g5" kvg:element="亠" kvg:position="top">
-					<path id="kvg:05b22-Kaisho-s4" kvg:type="㇑a" d="M61.07,12.75c1.94,0.9,4.18,3.75,5.15,6.18"/>
-					<path id="kvg:05b22-Kaisho-s5" kvg:type="㇐" d="M40.62,25.35c1.24,0.25,2.34,0.51,3.77,0.34c8.52-1.03,32.28-4.36,42.2-4.86c1.46-0.07,2.21,0.03,3.29,0.44"/>
-				</g>
+			<g id="kvg:05b22-Kaisho-g4" kvg:element="亠" kvg:position="top">
+				<path id="kvg:05b22-Kaisho-s4" kvg:type="㇑a" d="M61.07,12.75c1.94,0.9,4.18,3.75,5.15,6.18"/>
+				<path id="kvg:05b22-Kaisho-s5" kvg:type="㇐" d="M40.62,25.35c1.24,0.25,2.34,0.51,3.77,0.34c8.52-1.03,32.28-4.36,42.2-4.86c1.46-0.07,2.21,0.03,3.29,0.44"/>
 			</g>
-			<g id="kvg:05b22-Kaisho-g6" kvg:position="left">
-				<g id="kvg:05b22-Kaisho-g7" kvg:element="八">
-					<g id="kvg:05b22-Kaisho-g8" kvg:element="口" kvg:variant="true">
-						<path id="kvg:05b22-Kaisho-s6" kvg:type="㇒" d="M54.77,28.14c0.03,0.24,0.07,0.61-0.07,0.95c-0.83,2.01-5.61,6.42-12.14,9.12"/>
-					</g>
-				</g>
-				<g id="kvg:05b22-Kaisho-g9" kvg:element="口" kvg:variant="true" kvg:position="right">
-					<path id="kvg:05b22-Kaisho-s7" kvg:type="㇔" d="M74.52,27.08c4.34,1.35,11.21,5.54,12.29,7.63"/>
-				</g>
+			<g id="kvg:05b22-Kaisho-g5" kvg:element="八">
+				<path id="kvg:05b22-Kaisho-s6" kvg:type="㇒" d="M54.77,28.14c0.03,0.24,0.07,0.61-0.07,0.95c-0.83,2.01-5.61,6.42-12.14,9.12"/>
+				<path id="kvg:05b22-Kaisho-s7" kvg:type="㇔" d="M74.52,27.08c4.34,1.35,11.21,5.54,12.29,7.63"/>
 			</g>
 		</g>
-		<g id="kvg:05b22-Kaisho-g10" kvg:element="三" kvg:part="1">
-			<g id="kvg:05b22-Kaisho-g11" kvg:element="一" kvg:position="top">
+		<g id="kvg:05b22-Kaisho-g6" kvg:element="三" kvg:part="1">
+			<g id="kvg:05b22-Kaisho-g7" kvg:element="一" kvg:position="top">
 				<path id="kvg:05b22-Kaisho-s8" kvg:type="㇐" d="M46.75,43.52c0.71,0.29,3.52,0.35,4.24,0.29c6.51-0.56,20.76-3.81,27.77-4.45c1.18-0.11,1.9,0.14,2.5,0.28"/>
 			</g>
 		</g>
 		<path id="kvg:05b22-Kaisho-s9" kvg:type="㇑" d="M54.87,37.75c1.09,0.5,1.74,2.25,1.96,3.25c0.22,1,1,16.25,0.78,22.5"/>
 		<path id="kvg:05b22-Kaisho-s10" kvg:type="㇑" d="M72.37,34.25c0.88,1,1.72,2.24,1.46,3.75c-1.33,7.75-2.33,14.5-3.33,23"/>
-		<g id="kvg:05b22-Kaisho-g12" kvg:element="三" kvg:part="1" kvg:position="bottom">
-			<g id="kvg:05b22-Kaisho-g13" kvg:element="一">
+		<g id="kvg:05b22-Kaisho-g8" kvg:element="三" kvg:part="1" kvg:position="bottom">
+			<g id="kvg:05b22-Kaisho-g9" kvg:element="一">
 				<path id="kvg:05b22-Kaisho-s11" kvg:type="㇐" d="M46.75,53.52c0.71,0.29,3.52,0.35,4.24,0.29c6.51-0.56,20.76-2.81,27.77-3.45c1.18-0.11,1.9,0.14,2.5,0.28"/>
 			</g>
-			<g id="kvg:05b22-Kaisho-g14" kvg:element="一">
+			<g id="kvg:05b22-Kaisho-g10" kvg:element="一">
 				<path id="kvg:05b22-Kaisho-s12" kvg:type="㇐" d="M38.25,64.89c0.94,0.38,2.66,0.42,3.6,0.38c7.4-0.27,42.57-5.23,47.11-4.88c1.56,0.12,2.5,0.18,3.29,0.37"/>
 			</g>
 		</g>
-		<g id="kvg:05b22-Kaisho-g15" kvg:element="衣" kvg:part="2" kvg:position="bottom">
+		<g id="kvg:05b22-Kaisho-g11" kvg:element="𧘇" kvg:position="bottom">
 			<path id="kvg:05b22-Kaisho-s13" kvg:type="㇒" d="M58.53,64.39c0.06,0.55,0.24,1.46-0.12,2.2c-2.34,4.78-9.95,13.49-21.65,21.02"/>
 			<path id="kvg:05b22-Kaisho-s14" kvg:type="㇙" d="M53.09,77.45c0.32,0.35,0.66,0.7,0.66,1.31c-0.02,7.77-0.21,12.16-0.21,13.47s0.78,2.06,1.77,1.08c0.99-0.99,10.5-8.79,11.82-9.77"/>
 			<path id="kvg:05b22-Kaisho-s15" kvg:type="㇒" d="M79.64,63.69c0.02,0.26,0.25,1.26,0.11,1.61c-0.89,2.16-3.68,5.24-8.22,9.53"/>

--- a/kanji/05b22-KaishoVtLst.svg
+++ b/kanji/05b22-KaishoVtLst.svg
@@ -42,41 +42,33 @@ kvg:type CDATA #IMPLIED >
 		<path id="kvg:05b22-KaishoVtLst-s2" kvg:type="㇒" d="M36.89,38.41c0.07,1.21,0.12,4.16-0.14,5.92c-2.13,14.21-8.29,34.35-23.54,44.92"/>
 		<path id="kvg:05b22-KaishoVtLst-s3" kvg:type="㇀/㇐" d="M12,49.22c0.62,0.99,1.94,1.2,3.59,0.96C17.36,49.93,31,46,40,43.62"/>
 	</g>
-	<g id="kvg:05b22-KaishoVtLst-g2" kvg:element="襄" kvg:variant="true" kvg:position="right">
+	<g id="kvg:05b22-KaishoVtLst-g2" kvg:element="㐮" kvg:variant="true" kvg:original="襄" kvg:position="right">
 		<g id="kvg:05b22-KaishoVtLst-g3" kvg:element="六" kvg:variant="true">
-			<g id="kvg:05b22-KaishoVtLst-g4" kvg:element="衣" kvg:part="1">
-				<g id="kvg:05b22-KaishoVtLst-g5" kvg:element="亠" kvg:position="top">
-					<path id="kvg:05b22-KaishoVtLst-s4" kvg:type="㇑a" d="M61.07,12.75c1.94,0.9,4.18,3.75,5.15,6.18"/>
-					<path id="kvg:05b22-KaishoVtLst-s5" kvg:type="㇐" d="M40.62,25.35c1.24,0.25,2.34,0.51,3.77,0.34c8.52-1.03,32.28-4.36,42.2-4.86c1.46-0.07,2.21,0.03,3.29,0.44"/>
-				</g>
+			<g id="kvg:05b22-KaishoVtLst-g4" kvg:element="亠" kvg:position="top">
+				<path id="kvg:05b22-KaishoVtLst-s4" kvg:type="㇑a" d="M61.07,12.75c1.94,0.9,4.18,3.75,5.15,6.18"/>
+				<path id="kvg:05b22-KaishoVtLst-s5" kvg:type="㇐" d="M40.62,25.35c1.24,0.25,2.34,0.51,3.77,0.34c8.52-1.03,32.28-4.36,42.2-4.86c1.46-0.07,2.21,0.03,3.29,0.44"/>
 			</g>
-			<g id="kvg:05b22-KaishoVtLst-g6" kvg:position="left">
-				<g id="kvg:05b22-KaishoVtLst-g7" kvg:element="八">
-					<g id="kvg:05b22-KaishoVtLst-g8" kvg:element="口" kvg:variant="true">
-						<path id="kvg:05b22-KaishoVtLst-s6" kvg:type="㇒" d="M54.77,28.14c0.03,0.24,0.07,0.61-0.07,0.95c-0.83,2.01-5.61,6.42-12.14,9.12"/>
-					</g>
-				</g>
-				<g id="kvg:05b22-KaishoVtLst-g9" kvg:element="口" kvg:variant="true" kvg:position="right">
-					<path id="kvg:05b22-KaishoVtLst-s7" kvg:type="㇔" d="M74.52,27.08c4.34,1.35,11.21,5.54,12.29,7.63"/>
-				</g>
+			<g id="kvg:05b22-KaishoVtLst-g5" kvg:element="八">
+				<path id="kvg:05b22-KaishoVtLst-s6" kvg:type="㇒" d="M54.77,28.14c0.03,0.24,0.07,0.61-0.07,0.95c-0.83,2.01-5.61,6.42-12.14,9.12"/>
+				<path id="kvg:05b22-KaishoVtLst-s7" kvg:type="㇔" d="M74.52,27.08c4.34,1.35,11.21,5.54,12.29,7.63"/>
 			</g>
 		</g>
-		<g id="kvg:05b22-KaishoVtLst-g10" kvg:element="三" kvg:part="1">
-			<g id="kvg:05b22-KaishoVtLst-g11" kvg:element="一" kvg:position="top">
+		<g id="kvg:05b22-KaishoVtLst-g6" kvg:element="三" kvg:part="1">
+			<g id="kvg:05b22-KaishoVtLst-g7" kvg:element="一" kvg:position="top">
 				<path id="kvg:05b22-KaishoVtLst-s8" kvg:type="㇐" d="M46.75,43.52c0.71,0.29,3.52,0.35,4.24,0.29c6.51-0.56,20.76-3.81,27.77-4.45c1.18-0.11,1.9,0.14,2.5,0.28"/>
 			</g>
 		</g>
-		<g id="kvg:05b22-KaishoVtLst-g12" kvg:element="三" kvg:part="1" kvg:position="bottom">
-			<g id="kvg:05b22-KaishoVtLst-g13" kvg:element="一">
+		<g id="kvg:05b22-KaishoVtLst-g8" kvg:element="三" kvg:part="1" kvg:position="bottom">
+			<g id="kvg:05b22-KaishoVtLst-g9" kvg:element="一">
 				<path id="kvg:05b22-KaishoVtLst-s9" kvg:type="㇐" d="M46.75,53.52c0.71,0.29,3.52,0.35,4.24,0.29c6.51-0.56,20.76-2.81,27.77-3.45c1.18-0.11,1.9,0.14,2.5,0.28"/>
 			</g>
-			<g id="kvg:05b22-KaishoVtLst-g14" kvg:element="一">
+			<g id="kvg:05b22-KaishoVtLst-g10" kvg:element="一">
 				<path id="kvg:05b22-KaishoVtLst-s10" kvg:type="㇐" d="M38.25,64.89c0.94,0.38,2.66,0.42,3.6,0.38c7.4-0.27,42.57-5.23,47.11-4.88c1.56,0.12,2.5,0.18,3.29,0.37"/>
 			</g>
 			<path id="kvg:05b22-KaishoVtLst-s11" kvg:type="㇑" d="M54.87,37.75c1.09,0.5,1.74,2.25,1.96,3.25c0.22,1,1,16.25,0.78,22.5"/>
 			<path id="kvg:05b22-KaishoVtLst-s12" kvg:type="㇑" d="M72.37,34.25c0.88,1,1.72,2.24,1.46,3.75c-1.33,7.75-2.33,14.5-3.33,23"/>
 		</g>
-		<g id="kvg:05b22-KaishoVtLst-g15" kvg:element="衣" kvg:part="2" kvg:position="bottom">
+		<g id="kvg:05b22-KaishoVtLst-g11" kvg:element="𧘇" kvg:position="bottom">
 			<path id="kvg:05b22-KaishoVtLst-s13" kvg:type="㇒" d="M58.53,64.39c0.06,0.55,0.24,1.46-0.12,2.2c-2.34,4.78-9.95,13.49-21.65,21.02"/>
 			<path id="kvg:05b22-KaishoVtLst-s14" kvg:type="㇙" d="M53.09,77.45c0.32,0.35,0.66,0.7,0.66,1.31c-0.02,7.77-0.21,12.16-0.21,13.47s0.78,2.06,1.77,1.08c0.99-0.99,10.5-8.79,11.82-9.77"/>
 			<path id="kvg:05b22-KaishoVtLst-s15" kvg:type="㇒" d="M79.64,63.69c0.02,0.26,0.25,1.26,0.11,1.61c-0.89,2.16-3.68,5.24-8.22,9.53"/>

--- a/kanji/05b22.svg
+++ b/kanji/05b22.svg
@@ -42,41 +42,33 @@ kvg:type CDATA #IMPLIED >
 		<path id="kvg:05b22-s2" kvg:type="㇒" d="M36.89,38.16c0.49,1.71,0.39,4.16,0.11,5.92C34.88,57.25,29.5,77,13.21,89.25"/>
 		<path id="kvg:05b22-s3" kvg:type="㇀/㇐" d="M12,49.47c0.88,1.03,1.98,1.15,3.59,0.71C21.75,48.5,29,46.12,39.5,43.12"/>
 	</g>
-	<g id="kvg:05b22-g2" kvg:element="襄" kvg:variant="true" kvg:position="right" kvg:phon="襄V">
+	<g id="kvg:05b22-g2" kvg:element="㐮" kvg:variant="true" kvg:original="襄" kvg:position="right" kvg:phon="襄V">
 		<g id="kvg:05b22-g3" kvg:element="六" kvg:variant="true">
-			<g id="kvg:05b22-g4" kvg:element="衣" kvg:part="1">
-				<g id="kvg:05b22-g5" kvg:element="亠" kvg:position="top">
-					<path id="kvg:05b22-s4" kvg:type="㇑a" d="M63.39,13.25c1.05,1.05,1.35,2.25,1.35,3.59c0,1.16-0.09,3.28-0.09,5.18"/>
-					<path id="kvg:05b22-s5" kvg:type="㇐" d="M40.62,25.1c2.47,0.49,5.12,0.18,7.63-0.13c9.05-1.12,24.83-3.34,34.49-4.12c2.2-0.18,5.03-0.37,7.15,0.43"/>
-				</g>
+			<g id="kvg:05b22-g4" kvg:element="亠" kvg:position="top">
+				<path id="kvg:05b22-s4" kvg:type="㇑a" d="M63.39,13.25c1.05,1.05,1.35,2.25,1.35,3.59c0,1.16-0.09,3.28-0.09,5.18"/>
+				<path id="kvg:05b22-s5" kvg:type="㇐" d="M40.62,25.1c2.47,0.49,5.12,0.18,7.63-0.13c9.05-1.12,24.83-3.34,34.49-4.12c2.2-0.18,5.03-0.37,7.15,0.43"/>
 			</g>
-			<g id="kvg:05b22-g6" kvg:position="left">
-				<g id="kvg:05b22-g7" kvg:element="八">
-					<g id="kvg:05b22-g8" kvg:element="口" kvg:variant="true">
-						<path id="kvg:05b22-s6" kvg:type="㇒" d="M54.77,27.64c0.03,0.26,0.07,0.66-0.07,1.03c-0.69,1.82-4.15,5.49-9.08,8.33"/>
-					</g>
-				</g>
-				<g id="kvg:05b22-g9" kvg:element="口" kvg:variant="true" kvg:position="right">
-					<path id="kvg:05b22-s7" kvg:type="㇔" d="M74.77,27.08c4.34,1.35,11.21,5.54,12.29,7.63"/>
-				</g>
+			<g id="kvg:05b22-g5" kvg:element="八">
+				<path id="kvg:05b22-s6" kvg:type="㇒" d="M54.77,27.64c0.03,0.26,0.07,0.66-0.07,1.03c-0.69,1.82-4.15,5.49-9.08,8.33"/>
+				<path id="kvg:05b22-s7" kvg:type="㇔" d="M74.77,27.08c4.34,1.35,11.21,5.54,12.29,7.63"/>
 			</g>
 		</g>
-		<g id="kvg:05b22-g10" kvg:element="三" kvg:part="1">
-			<g id="kvg:05b22-g11" kvg:element="一" kvg:position="top">
+		<g id="kvg:05b22-g6" kvg:element="三" kvg:part="1">
+			<g id="kvg:05b22-g7" kvg:element="一" kvg:position="top">
 				<path id="kvg:05b22-s8" kvg:type="㇐" d="M46.75,43.02c1.83,0.75,4.46,0.52,6.37,0.31c8.63-0.95,16.01-2.07,24.4-3.34c1.2-0.18,2.54-0.39,3.74-0.09"/>
 			</g>
 		</g>
 		<path id="kvg:05b22-s9" kvg:type="㇑a" d="M56.12,38c0.88,0.88,1.21,2.38,1.21,3.75c0,1.02,0.3,10.25,0.53,20.5"/>
 		<path id="kvg:05b22-s10" kvg:type="㇑a" d="M73.12,34c0.63,1,0.64,2.48,0.46,4C72.38,48,72,52.25,71,60.75"/>
-		<g id="kvg:05b22-g12" kvg:element="三" kvg:part="1" kvg:position="bottom">
-			<g id="kvg:05b22-g13" kvg:element="一">
+		<g id="kvg:05b22-g8" kvg:element="三" kvg:part="1" kvg:position="bottom">
+			<g id="kvg:05b22-g9" kvg:element="一">
 				<path id="kvg:05b22-s11" kvg:type="㇐" d="M47.5,53.27c2.11,0.86,4.71,0.51,6.9,0.28c6.67-0.72,17.06-2.43,23.36-3.09c1.13-0.12,2.36-0.34,3.49-0.06"/>
 			</g>
-			<g id="kvg:05b22-g14" kvg:element="一">
+			<g id="kvg:05b22-g10" kvg:element="一">
 				<path id="kvg:05b22-s12" kvg:type="㇐" d="M39,64.64c2.17,0.88,5.55,0.46,7.78,0.06c9.1-1.63,26.35-3.32,38.85-4.24c2.25-0.17,4.25-0.21,6.87,0.05"/>
 			</g>
 		</g>
-		<g id="kvg:05b22-g15" kvg:element="衣" kvg:part="2" kvg:position="bottom">
+		<g id="kvg:05b22-g11" kvg:element="𧘇" kvg:position="bottom">
 			<path id="kvg:05b22-s13" kvg:type="㇒" d="M58.28,65.39c0.06,0.55-0.01,1.46-0.37,2.2c-2.34,4.78-9.2,11.24-20.9,18.77"/>
 			<path id="kvg:05b22-s14" kvg:type="㇙" d="M53.34,77.45c0.73,0.73,0.91,1.8,0.91,3.06c0,5.56,0.02,8.61,0.03,10.24c0.02,2.56,0.67,3.19,2.9,1.29c2.58-2.21,8.07-7.29,10.45-9.25"/>
 			<path id="kvg:05b22-s15" kvg:type="㇒" d="M80.14,64.19c0.04,0.5-0.35,1.31-0.67,1.69c-1.98,2.38-3.05,3.53-7.2,7.45"/>

--- a/kanji/07a63-Kaisho.svg
+++ b/kanji/07a63-Kaisho.svg
@@ -48,41 +48,33 @@ kvg:type CDATA #IMPLIED >
 			<path id="kvg:07a63-Kaisho-s5" kvg:type="㇔/㇏" d="M31.5,54c3.25,1.75,6,5.25,7.75,7.5"/>
 		</g>
 	</g>
-	<g id="kvg:07a63-Kaisho-g4" kvg:element="襄" kvg:variant="true" kvg:position="right">
+	<g id="kvg:07a63-Kaisho-g4" kvg:element="㐮" kvg:variant="true" kvg:original="襄" kvg:position="right">
 		<g id="kvg:07a63-Kaisho-g5" kvg:element="六" kvg:variant="true">
-			<g id="kvg:07a63-Kaisho-g6" kvg:element="衣" kvg:part="1">
-				<g id="kvg:07a63-Kaisho-g7" kvg:element="亠" kvg:position="top">
-					<path id="kvg:07a63-Kaisho-s6" kvg:type="㇑a" d="M61.6,10.5c1.9,1.5,4.65,4.75,5.84,6.93"/>
-					<path id="kvg:07a63-Kaisho-s7" kvg:type="㇐" d="M45.87,23.6c1.24,0.25,2.34,0.51,3.77,0.34c8.52-1.03,27.28-3.36,37.2-3.86c1.46-0.07,2.21,0.03,3.29,0.44"/>
-				</g>
+			<g id="kvg:07a63-Kaisho-g6" kvg:element="亠" kvg:position="top">
+				<path id="kvg:07a63-Kaisho-s6" kvg:type="㇑a" d="M61.6,10.5c1.9,1.5,4.65,4.75,5.84,6.93"/>
+				<path id="kvg:07a63-Kaisho-s7" kvg:type="㇐" d="M45.87,23.6c1.24,0.25,2.34,0.51,3.77,0.34c8.52-1.03,27.28-3.36,37.2-3.86c1.46-0.07,2.21,0.03,3.29,0.44"/>
 			</g>
-			<g id="kvg:07a63-Kaisho-g8" kvg:position="left">
-				<g id="kvg:07a63-Kaisho-g9" kvg:element="八">
-					<g id="kvg:07a63-Kaisho-g10" kvg:element="口" kvg:variant="true">
-						<path id="kvg:07a63-Kaisho-s8" kvg:type="㇒" d="M57.52,27.39c0.03,0.27,0.06,0.7-0.06,1.1c-0.71,2.31-4.81,7.38-10.41,10.48"/>
-					</g>
-				</g>
-				<g id="kvg:07a63-Kaisho-g11" kvg:element="口" kvg:variant="true" kvg:position="right">
-					<path id="kvg:07a63-Kaisho-s9" kvg:type="㇔" d="M76.52,26.08c4.43,1.3,11.44,5.36,12.54,7.38"/>
-				</g>
+			<g id="kvg:07a63-Kaisho-g7" kvg:element="八">
+				<path id="kvg:07a63-Kaisho-s8" kvg:type="㇒" d="M57.52,27.39c0.03,0.27,0.06,0.7-0.06,1.1c-0.71,2.31-4.81,7.38-10.41,10.48"/>
+				<path id="kvg:07a63-Kaisho-s9" kvg:type="㇔" d="M76.52,26.08c4.43,1.3,11.44,5.36,12.54,7.38"/>
 			</g>
 		</g>
-		<g id="kvg:07a63-Kaisho-g12" kvg:element="三" kvg:part="1">
-			<g id="kvg:07a63-Kaisho-g13" kvg:element="一" kvg:position="top">
+		<g id="kvg:07a63-Kaisho-g8" kvg:element="三" kvg:part="1">
+			<g id="kvg:07a63-Kaisho-g9" kvg:element="一" kvg:position="top">
 				<path id="kvg:07a63-Kaisho-s10" kvg:type="㇐" d="M50.5,43.27c0.71,0.29,3.52,0.35,4.24,0.29C61.25,43,75.5,40.75,82.5,40.1c1.18-0.11,1.9,0.14,2.5,0.28"/>
 			</g>
 		</g>
 		<path id="kvg:07a63-Kaisho-s11" kvg:type="㇑" d="M58.62,37.5c1.09,0.5,1.74,2.25,1.96,3.25c0.22,1,0,16.25-0.22,22.5"/>
 		<path id="kvg:07a63-Kaisho-s12" kvg:type="㇑" d="M75.62,33.5c0.88,1,1.72,2.24,1.46,3.75c-1.33,7.75-1.33,15-2.33,23.5"/>
-		<g id="kvg:07a63-Kaisho-g14" kvg:element="三" kvg:part="1" kvg:position="bottom">
-			<g id="kvg:07a63-Kaisho-g15" kvg:element="一">
+		<g id="kvg:07a63-Kaisho-g10" kvg:element="三" kvg:part="1" kvg:position="bottom">
+			<g id="kvg:07a63-Kaisho-g11" kvg:element="一">
 				<path id="kvg:07a63-Kaisho-s13" kvg:type="㇐" d="M50.5,53.27c0.71,0.29,3.52,0.35,4.24,0.29C61.25,53,77,50.75,84,50.1c1.18-0.11,1.9,0.14,2.5,0.28"/>
 			</g>
-			<g id="kvg:07a63-Kaisho-g16" kvg:element="一">
+			<g id="kvg:07a63-Kaisho-g12" kvg:element="一">
 				<path id="kvg:07a63-Kaisho-s14" kvg:type="㇐" d="M45,63.64c0.94,0.38,2.66,0.42,3.6,0.38c7.4-0.27,38.07-3.73,42.61-3.38c1.56,0.12,2.5,0.18,3.29,0.37"/>
 			</g>
 		</g>
-		<g id="kvg:07a63-Kaisho-g17" kvg:element="衣" kvg:part="2" kvg:position="bottom">
+		<g id="kvg:07a63-Kaisho-g13" kvg:element="𧘇" kvg:position="bottom">
 			<path id="kvg:07a63-Kaisho-s15" kvg:type="㇒" d="M63.27,65.64c0.06,0.47,0.25,1.25-0.12,1.89c-2.36,4.11-10.06,11.6-21.9,18.08"/>
 			<path id="kvg:07a63-Kaisho-s16" kvg:type="㇙" d="M56.84,78.2c0.32,0.35,0.66,0.7,0.66,1.31c-0.02,7.77-0.21,14.16-0.21,15.47s0.78,2.06,1.77,1.08c0.99-0.99,10.5-8.79,11.82-9.77"/>
 			<path id="kvg:07a63-Kaisho-s17" kvg:type="㇒" d="M82.65,67.44c0.02,0.23,0.24,1.09,0.11,1.39c-0.86,1.87-3.57,4.53-7.97,8.24"/>

--- a/kanji/07a63.svg
+++ b/kanji/07a63.svg
@@ -48,41 +48,33 @@ kvg:type CDATA #IMPLIED >
 			<path id="kvg:07a63-s5" kvg:type="㇔/㇏" d="M31.38,52.12c3.51,2.13,6.48,6.39,8.38,9.12"/>
 		</g>
 	</g>
-	<g id="kvg:07a63-g4" kvg:element="襄" kvg:variant="true" kvg:position="right">
+	<g id="kvg:07a63-g4" kvg:element="㐮" kvg:variant="true" kvg:original="襄" kvg:position="right">
 		<g id="kvg:07a63-g5" kvg:element="六" kvg:variant="true">
-			<g id="kvg:07a63-g6" kvg:element="衣" kvg:part="1">
-				<g id="kvg:07a63-g7" kvg:element="亠" kvg:position="top">
-					<path id="kvg:07a63-s6" kvg:type="㇑a" d="M64.14,11c0.93,0.93,1.35,2,1.35,3.34c0,2.77-0.09,4.41-0.09,6.93"/>
-					<path id="kvg:07a63-s7" kvg:type="㇐" d="M45.62,23.35c2.61,0.52,5.39,0.39,8.03,0.08c8.07-0.98,20.29-2.65,28.99-3.32c2.42-0.18,5.11-0.48,7.5-0.09"/>
-				</g>
+			<g id="kvg:07a63-g6" kvg:element="亠" kvg:position="top">
+				<path id="kvg:07a63-s6" kvg:type="㇑a" d="M64.14,11c0.93,0.93,1.35,2,1.35,3.34c0,2.77-0.09,4.41-0.09,6.93"/>
+				<path id="kvg:07a63-s7" kvg:type="㇐" d="M45.62,23.35c2.61,0.52,5.39,0.39,8.03,0.08c8.07-0.98,20.29-2.65,28.99-3.32c2.42-0.18,5.11-0.48,7.5-0.09"/>
 			</g>
-			<g id="kvg:07a63-g8" kvg:position="left">
-				<g id="kvg:07a63-g9" kvg:element="八">
-					<g id="kvg:07a63-g10" kvg:element="口" kvg:variant="true">
-						<path id="kvg:07a63-s8" kvg:type="㇒" d="M57.25,26.62c0.09,0.86-0.1,1.67-0.55,2.42c-1.35,2.77-4.7,6.46-9.52,10.05"/>
-					</g>
-				</g>
-				<g id="kvg:07a63-g11" kvg:element="口" kvg:variant="true" kvg:position="right">
-					<path id="kvg:07a63-s9" kvg:type="㇔" d="M75.39,25.83c4.91,1.35,12.69,5.54,13.92,7.63"/>
-				</g>
+			<g id="kvg:07a63-g7" kvg:element="八">
+				<path id="kvg:07a63-s8" kvg:type="㇒" d="M57.25,26.62c0.09,0.86-0.1,1.67-0.55,2.42c-1.35,2.77-4.7,6.46-9.52,10.05"/>
+				<path id="kvg:07a63-s9" kvg:type="㇔" d="M75.39,25.83c4.91,1.35,12.69,5.54,13.92,7.63"/>
 			</g>
 		</g>
-		<g id="kvg:07a63-g12" kvg:element="三" kvg:part="1">
-			<g id="kvg:07a63-g13" kvg:element="一" kvg:position="top">
+		<g id="kvg:07a63-g8" kvg:element="三" kvg:part="1">
+			<g id="kvg:07a63-g9" kvg:element="一" kvg:position="top">
 				<path id="kvg:07a63-s10" kvg:type="㇐" d="M51.5,42.27c2.38,0.61,3.64,0.72,5.76,0.52c6.06-0.55,16.74-1.77,22.85-2.44c1.68-0.18,3.22-0.37,4.89,0.04"/>
 			</g>
 		</g>
 		<path id="kvg:07a63-s11" kvg:type="㇑" d="M59.12,37.25c1.07,1.06,1.21,2.38,1.21,3.75c0,1.02,0.03,15.88,0.03,21"/>
 		<path id="kvg:07a63-s12" kvg:type="㇑" d="M75.62,33.25c0.88,1,1.1,2.22,0.96,3.75c-0.7,7.5-1.2,14.38-1.83,23.75"/>
-		<g id="kvg:07a63-g14" kvg:element="三" kvg:part="1" kvg:position="bottom">
-			<g id="kvg:07a63-g15" kvg:element="一">
+		<g id="kvg:07a63-g10" kvg:element="三" kvg:part="1" kvg:position="bottom">
+			<g id="kvg:07a63-g11" kvg:element="一">
 				<path id="kvg:07a63-s13" kvg:type="㇐" d="M49.5,53.02c2.25,0.92,5.05,0.73,7.37,0.49c6.7-0.68,18.43-2.16,25.26-2.89c1.61-0.17,3.52-0.62,5.12-0.23"/>
 			</g>
-			<g id="kvg:07a63-g16" kvg:element="一">
+			<g id="kvg:07a63-g12" kvg:element="一">
 				<path id="kvg:07a63-s14" kvg:type="㇐" d="M45,63.64c2.4,0.97,5.78,0.27,8.25,0.07c8.92-0.72,25.36-2.42,33.62-2.94c2.57-0.16,5.34-0.38,7.87,0.24"/>
 			</g>
 		</g>
-		<g id="kvg:07a63-g17" kvg:element="衣" kvg:part="2" kvg:position="bottom">
+		<g id="kvg:07a63-g13" kvg:element="𧘇" kvg:position="bottom">
 			<path id="kvg:07a63-s15" kvg:type="㇒" d="M63.62,65.12c-0.12,1.38-0.48,2.12-1.45,3.37c-3.2,4.12-10.45,10.37-20.92,15.87"/>
 			<path id="kvg:07a63-s16" kvg:type="㇙" d="M56.34,78.2c0.79,0.79,0.91,1.8,0.91,3.06c0,5.72,0.02,9.74,0.03,11.99c0.01,2.94,0.58,3.8,2.97,1.76c2.84-2.43,9.53-7.9,10.62-8.72"/>
 			<path id="kvg:07a63-s17" kvg:type="㇒" d="M82.65,67.19c0.09,0.92-0.19,1.6-0.71,2.35c-1.22,1.79-2.97,3.16-6.66,6.28"/>

--- a/kanji/08b72-Kaisho.svg
+++ b/kanji/08b72-Kaisho.svg
@@ -48,41 +48,33 @@ kvg:type CDATA #IMPLIED >
 			<path id="kvg:08b72-Kaisho-s7" kvg:type="㇐b" d="M21.42,91.05c5.37-0.54,8.68-0.97,16.06-1.81"/>
 		</g>
 	</g>
-	<g id="kvg:08b72-Kaisho-g3" kvg:element="襄" kvg:variant="true" kvg:position="right">
+	<g id="kvg:08b72-Kaisho-g3" kvg:element="㐮" kvg:variant="true" kvg:original="襄" kvg:position="right">
 		<g id="kvg:08b72-Kaisho-g4" kvg:element="六" kvg:variant="true">
-			<g id="kvg:08b72-Kaisho-g5" kvg:element="衣" kvg:part="1">
-				<g id="kvg:08b72-Kaisho-g6" kvg:element="亠" kvg:position="top">
-					<path id="kvg:08b72-Kaisho-s8" kvg:type="㇑a" d="M62.11,10.5c2.39,1.69,4.39,4.35,5.33,7.18"/>
-					<path id="kvg:08b72-Kaisho-s9" kvg:type="㇐" d="M46.12,23.85c1.24,0.25,2.34,0.51,3.77,0.34c8.52-1.03,27.28-3.36,37.2-3.86c1.46-0.07,2.21,0.03,3.29,0.44"/>
-				</g>
+			<g id="kvg:08b72-Kaisho-g5" kvg:element="亠" kvg:position="top">
+				<path id="kvg:08b72-Kaisho-s8" kvg:type="㇑a" d="M62.11,10.5c2.39,1.69,4.39,4.35,5.33,7.18"/>
+				<path id="kvg:08b72-Kaisho-s9" kvg:type="㇐" d="M46.12,23.85c1.24,0.25,2.34,0.51,3.77,0.34c8.52-1.03,27.28-3.36,37.2-3.86c1.46-0.07,2.21,0.03,3.29,0.44"/>
 			</g>
-			<g id="kvg:08b72-Kaisho-g7" kvg:position="left">
-				<g id="kvg:08b72-Kaisho-g8" kvg:element="八">
-					<g id="kvg:08b72-Kaisho-g9" kvg:element="口" kvg:variant="true">
-						<path id="kvg:08b72-Kaisho-s10" kvg:type="㇒" d="M57.77,27.64c0.03,0.27,0.06,0.7-0.06,1.1c-0.71,2.31-4.81,7.38-10.41,10.48"/>
-					</g>
-				</g>
-				<g id="kvg:08b72-Kaisho-g10" kvg:element="口" kvg:variant="true" kvg:position="right">
-					<path id="kvg:08b72-Kaisho-s11" kvg:type="㇔" d="M76.77,26.33c4.43,1.3,11.44,5.36,12.54,7.38"/>
-				</g>
+			<g id="kvg:08b72-Kaisho-g6" kvg:element="八">
+				<path id="kvg:08b72-Kaisho-s10" kvg:type="㇒" d="M57.77,27.64c0.03,0.27,0.06,0.7-0.06,1.1c-0.71,2.31-4.81,7.38-10.41,10.48"/>
+				<path id="kvg:08b72-Kaisho-s11" kvg:type="㇔" d="M76.77,26.33c4.43,1.3,11.44,5.36,12.54,7.38"/>
 			</g>
 		</g>
-		<g id="kvg:08b72-Kaisho-g11" kvg:element="三" kvg:part="1">
-			<g id="kvg:08b72-Kaisho-g12" kvg:element="一" kvg:position="top">
+		<g id="kvg:08b72-Kaisho-g7" kvg:element="三" kvg:part="1">
+			<g id="kvg:08b72-Kaisho-g8" kvg:element="一" kvg:position="top">
 				<path id="kvg:08b72-Kaisho-s12" kvg:type="㇐" d="M50.75,43.52c0.71,0.29,3.52,0.35,4.24,0.29c6.51-0.56,20.76-2.81,27.77-3.45c1.18-0.11,1.9,0.14,2.5,0.28"/>
 			</g>
 		</g>
 		<path id="kvg:08b72-Kaisho-s13" kvg:type="㇑" d="M58.87,37.75c1.09,0.5,1.74,2.25,1.96,3.25c0.22,1,0,16.25-0.22,22.5"/>
 		<path id="kvg:08b72-Kaisho-s14" kvg:type="㇑" d="M75.87,33.75c0.88,1,1.72,2.24,1.46,3.75C76,45.25,76,52.5,75,61"/>
-		<g id="kvg:08b72-Kaisho-g13" kvg:element="三" kvg:part="1" kvg:position="bottom">
-			<g id="kvg:08b72-Kaisho-g14" kvg:element="一">
+		<g id="kvg:08b72-Kaisho-g9" kvg:element="三" kvg:part="1" kvg:position="bottom">
+			<g id="kvg:08b72-Kaisho-g10" kvg:element="一">
 				<path id="kvg:08b72-Kaisho-s15" kvg:type="㇐" d="M50.75,53.52c0.71,0.29,3.52,0.35,4.24,0.29c6.51-0.56,22.26-2.81,29.27-3.45c1.18-0.11,1.9,0.14,2.5,0.28"/>
 			</g>
-			<g id="kvg:08b72-Kaisho-g15" kvg:element="一">
+			<g id="kvg:08b72-Kaisho-g11" kvg:element="一">
 				<path id="kvg:08b72-Kaisho-s16" kvg:type="㇐" d="M45.25,63.89c0.94,0.38,2.66,0.42,3.6,0.38c7.4-0.27,38.07-3.73,42.61-3.38c1.56,0.12,2.5,0.18,3.29,0.37"/>
 			</g>
 		</g>
-		<g id="kvg:08b72-Kaisho-g16" kvg:element="衣" kvg:part="2" kvg:position="bottom">
+		<g id="kvg:08b72-Kaisho-g12" kvg:element="𧘇" kvg:position="bottom">
 			<path id="kvg:08b72-Kaisho-s17" kvg:type="㇒" d="M63.52,65.89c0.06,0.47,0.25,1.25-0.12,1.89c-2.36,4.11-10.06,11.6-21.9,18.08"/>
 			<path id="kvg:08b72-Kaisho-s18" kvg:type="㇙" d="M57.09,78.45c0.32,0.35,0.66,0.7,0.66,1.31c-0.02,7.77-0.21,14.16-0.21,15.47s0.78,2.06,1.77,1.08c0.99-0.99,10.5-8.79,11.82-9.77"/>
 			<path id="kvg:08b72-Kaisho-s19" kvg:type="㇒" d="M82.9,67.69c0.02,0.23,0.24,1.09,0.11,1.39c-0.86,1.87-3.57,4.53-7.97,8.24"/>

--- a/kanji/08b72-KaishoVtLst.svg
+++ b/kanji/08b72-KaishoVtLst.svg
@@ -48,41 +48,33 @@ kvg:type CDATA #IMPLIED >
 			<path id="kvg:08b72-KaishoVtLst-s7" kvg:type="㇐b" d="M21.42,91.05c5.37-0.54,8.68-0.97,16.06-1.81"/>
 		</g>
 	</g>
-	<g id="kvg:08b72-KaishoVtLst-g3" kvg:element="襄" kvg:variant="true" kvg:position="right">
+	<g id="kvg:08b72-KaishoVtLst-g3" kvg:element="㐮" kvg:variant="true" kvg:original="襄" kvg:position="right">
 		<g id="kvg:08b72-KaishoVtLst-g4" kvg:element="六" kvg:variant="true">
-			<g id="kvg:08b72-KaishoVtLst-g5" kvg:element="衣" kvg:part="1">
-				<g id="kvg:08b72-KaishoVtLst-g6" kvg:element="亠" kvg:position="top">
-					<path id="kvg:08b72-KaishoVtLst-s8" kvg:type="㇑a" d="M62.11,10.5c2.39,1.69,4.39,4.35,5.33,7.18"/>
-					<path id="kvg:08b72-KaishoVtLst-s9" kvg:type="㇐" d="M46.12,23.85c1.24,0.25,2.34,0.51,3.77,0.34c8.52-1.03,27.28-3.36,37.2-3.86c1.46-0.07,2.21,0.03,3.29,0.44"/>
-				</g>
+			<g id="kvg:08b72-KaishoVtLst-g5" kvg:element="亠" kvg:position="top">
+				<path id="kvg:08b72-KaishoVtLst-s8" kvg:type="㇑a" d="M62.11,10.5c2.39,1.69,4.39,4.35,5.33,7.18"/>
+				<path id="kvg:08b72-KaishoVtLst-s9" kvg:type="㇐" d="M46.12,23.85c1.24,0.25,2.34,0.51,3.77,0.34c8.52-1.03,27.28-3.36,37.2-3.86c1.46-0.07,2.21,0.03,3.29,0.44"/>
 			</g>
-			<g id="kvg:08b72-KaishoVtLst-g7" kvg:position="left">
-				<g id="kvg:08b72-KaishoVtLst-g8" kvg:element="八">
-					<g id="kvg:08b72-KaishoVtLst-g9" kvg:element="口" kvg:variant="true">
-						<path id="kvg:08b72-KaishoVtLst-s10" kvg:type="㇒" d="M57.77,27.64c0.03,0.27,0.06,0.7-0.06,1.1c-0.71,2.31-4.81,7.38-10.41,10.48"/>
-					</g>
-				</g>
-				<g id="kvg:08b72-KaishoVtLst-g10" kvg:element="口" kvg:variant="true" kvg:position="right">
-					<path id="kvg:08b72-KaishoVtLst-s11" kvg:type="㇔" d="M76.77,26.33c4.43,1.3,11.44,5.36,12.54,7.38"/>
-				</g>
+			<g id="kvg:08b72-KaishoVtLst-g6" kvg:element="八">
+				<path id="kvg:08b72-KaishoVtLst-s10" kvg:type="㇒" d="M57.77,27.64c0.03,0.27,0.06,0.7-0.06,1.1c-0.71,2.31-4.81,7.38-10.41,10.48"/>
+				<path id="kvg:08b72-KaishoVtLst-s11" kvg:type="㇔" d="M76.77,26.33c4.43,1.3,11.44,5.36,12.54,7.38"/>
 			</g>
 		</g>
-		<g id="kvg:08b72-KaishoVtLst-g11" kvg:element="三" kvg:part="1">
-			<g id="kvg:08b72-KaishoVtLst-g12" kvg:element="一" kvg:position="top">
+		<g id="kvg:08b72-KaishoVtLst-g7" kvg:element="三" kvg:part="1">
+			<g id="kvg:08b72-KaishoVtLst-g8" kvg:element="一" kvg:position="top">
 				<path id="kvg:08b72-KaishoVtLst-s12" kvg:type="㇐" d="M50.75,43.52c0.71,0.29,3.52,0.35,4.24,0.29c6.51-0.56,20.76-2.81,27.77-3.45c1.18-0.11,1.9,0.14,2.5,0.28"/>
 			</g>
 		</g>
-		<g id="kvg:08b72-KaishoVtLst-g13" kvg:element="三" kvg:part="1" kvg:position="bottom">
-			<g id="kvg:08b72-KaishoVtLst-g14" kvg:element="一">
+		<g id="kvg:08b72-KaishoVtLst-g9" kvg:element="三" kvg:part="1" kvg:position="bottom">
+			<g id="kvg:08b72-KaishoVtLst-g10" kvg:element="一">
 				<path id="kvg:08b72-KaishoVtLst-s13" kvg:type="㇐" d="M50.75,53.52c0.71,0.29,3.52,0.35,4.24,0.29c6.51-0.56,22.26-2.81,29.27-3.45c1.18-0.11,1.9,0.14,2.5,0.28"/>
 			</g>
-			<g id="kvg:08b72-KaishoVtLst-g15" kvg:element="一">
+			<g id="kvg:08b72-KaishoVtLst-g11" kvg:element="一">
 				<path id="kvg:08b72-KaishoVtLst-s14" kvg:type="㇐" d="M45.25,63.89c0.94,0.38,2.66,0.42,3.6,0.38c7.4-0.27,38.07-3.73,42.61-3.38c1.56,0.12,2.5,0.18,3.29,0.37"/>
 			</g>
 			<path id="kvg:08b72-KaishoVtLst-s15" kvg:type="㇑" d="M58.87,37.75c1.09,0.5,1.74,2.25,1.96,3.25c0.22,1,0,16.25-0.22,22.5"/>
 			<path id="kvg:08b72-KaishoVtLst-s16" kvg:type="㇑" d="M75.87,33.75c0.88,1,1.72,2.24,1.46,3.75C76,45.25,76,52.5,75,61"/>
 		</g>
-		<g id="kvg:08b72-KaishoVtLst-g16" kvg:element="衣" kvg:part="2" kvg:position="bottom">
+		<g id="kvg:08b72-KaishoVtLst-g12" kvg:element="𧘇" kvg:position="bottom">
 			<path id="kvg:08b72-KaishoVtLst-s17" kvg:type="㇒" d="M63.52,65.89c0.06,0.47,0.25,1.25-0.12,1.89c-2.36,4.11-10.06,11.6-21.9,18.08"/>
 			<path id="kvg:08b72-KaishoVtLst-s18" kvg:type="㇙" d="M57.09,78.45c0.32,0.35,0.66,0.7,0.66,1.31c-0.02,7.77-0.21,14.16-0.21,15.47s0.78,2.06,1.77,1.08c0.99-0.99,10.5-8.79,11.82-9.77"/>
 			<path id="kvg:08b72-KaishoVtLst-s19" kvg:type="㇒" d="M82.9,67.69c0.02,0.23,0.24,1.09,0.11,1.39c-0.86,1.87-3.57,4.53-7.97,8.24"/>

--- a/kanji/08b72.svg
+++ b/kanji/08b72.svg
@@ -48,41 +48,33 @@ kvg:type CDATA #IMPLIED >
 			<path id="kvg:08b72-s7" kvg:type="㇐b" d="M22.92,90.8c4.39-0.44,5.9-0.81,10.88-1.39c1.12-0.13,2.45-0.28,3.68-0.17"/>
 		</g>
 	</g>
-	<g id="kvg:08b72-g3" kvg:element="襄" kvg:variant="true" kvg:position="right" kvg:phon="襄V">
+	<g id="kvg:08b72-g3" kvg:element="㐮" kvg:variant="true" kvg:original="襄" kvg:position="right" kvg:phon="襄V">
 		<g id="kvg:08b72-g4" kvg:element="六" kvg:variant="true">
-			<g id="kvg:08b72-g5" kvg:element="衣" kvg:part="1">
-				<g id="kvg:08b72-g6" kvg:element="亠" kvg:position="top">
-					<path id="kvg:08b72-s8" kvg:type="㇑a" d="M64.39,11.25c0.93,0.93,1.35,1.88,1.35,3.34c0,2.77-0.09,3.91-0.09,6.43"/>
-					<path id="kvg:08b72-s9" kvg:type="㇐" d="M46.12,23.85c2.32,0.46,4.79,0.22,7.15-0.07c8.31-1.01,21.49-2.78,30.49-3.48c2.18-0.17,4.62-0.42,6.63-0.03"/>
-				</g>
+			<g id="kvg:08b72-g5" kvg:element="亠" kvg:position="top">
+				<path id="kvg:08b72-s8" kvg:type="㇑a" d="M64.39,11.25c0.93,0.93,1.35,1.88,1.35,3.34c0,2.77-0.09,3.91-0.09,6.43"/>
+				<path id="kvg:08b72-s9" kvg:type="㇐" d="M46.12,23.85c2.32,0.46,4.79,0.22,7.15-0.07c8.31-1.01,21.49-2.78,30.49-3.48c2.18-0.17,4.62-0.42,6.63-0.03"/>
 			</g>
-			<g id="kvg:08b72-g7" kvg:position="left">
-				<g id="kvg:08b72-g8" kvg:element="八">
-					<g id="kvg:08b72-g9" kvg:element="口" kvg:variant="true">
-						<path id="kvg:08b72-s10" kvg:type="㇒" d="M57.77,27.14c0.08,0.67-0.04,1.29-0.37,1.86c-1.22,2.52-4.97,6.87-10.1,10.21"/>
-					</g>
-				</g>
-				<g id="kvg:08b72-g10" kvg:element="口" kvg:variant="true" kvg:position="right">
-					<path id="kvg:08b72-s11" kvg:type="㇔" d="M75.64,26.33c5,1.26,12.92,5.18,14.17,7.13"/>
-				</g>
+			<g id="kvg:08b72-g6" kvg:element="八">
+				<path id="kvg:08b72-s10" kvg:type="㇒" d="M57.77,27.14c0.08,0.67-0.04,1.29-0.37,1.86c-1.22,2.52-4.97,6.87-10.1,10.21"/>
+				<path id="kvg:08b72-s11" kvg:type="㇔" d="M75.64,26.33c5,1.26,12.92,5.18,14.17,7.13"/>
 			</g>
 		</g>
-		<g id="kvg:08b72-g11" kvg:element="三" kvg:part="1">
-			<g id="kvg:08b72-g12" kvg:element="一" kvg:position="top">
+		<g id="kvg:08b72-g7" kvg:element="三" kvg:part="1">
+			<g id="kvg:08b72-g8" kvg:element="一" kvg:position="top">
 				<path id="kvg:08b72-s12" kvg:type="㇐" d="M52.25,42.77c1.74,0.71,4.33,0.54,6.13,0.36c6.19-0.62,15.87-1.9,22.38-2.58c1.6-0.17,2.93-0.29,4.49,0.09"/>
 			</g>
 		</g>
 		<path id="kvg:08b72-s13" kvg:type="㇑a" d="M59.37,37.5c0.94,0.94,1.21,2.38,1.21,4c0,5.25,0.03,13.5,0.03,20.75"/>
 		<path id="kvg:08b72-s14" kvg:type="㇑a" d="M75.87,33.25c0.88,1.5,1.13,2.47,0.96,4C76.12,43.62,75.75,54.12,75,61"/>
-		<g id="kvg:08b72-g13" kvg:element="三" kvg:part="1" kvg:position="bottom">
-			<g id="kvg:08b72-g14" kvg:element="一">
+		<g id="kvg:08b72-g9" kvg:element="三" kvg:part="1" kvg:position="bottom">
+			<g id="kvg:08b72-g10" kvg:element="一">
 				<path id="kvg:08b72-s15" kvg:type="㇐" d="M50,53.27c1.95,0.79,4.35,0.54,6.38,0.35c6.88-0.64,20.03-2.12,26.99-2.85c1.46-0.15,2.7-0.23,4.12,0.12"/>
 			</g>
-			<g id="kvg:08b72-g15" kvg:element="一">
+			<g id="kvg:08b72-g11" kvg:element="一">
 				<path id="kvg:08b72-s16" kvg:type="㇐" d="M45.25,63.89c2.62,0.61,4.87,0.33,7.01,0.17c9.19-0.69,28.53-2.69,36.36-3.12c2-0.11,4.16-0.16,6.13,0.32"/>
 			</g>
 		</g>
-		<g id="kvg:08b72-g16" kvg:element="衣" kvg:part="2" kvg:position="bottom">
+		<g id="kvg:08b72-g12" kvg:element="𧘇" kvg:position="bottom">
 			<path id="kvg:08b72-s17" kvg:type="㇒" d="M63.27,65.39c0.06,0.47,0,1.25-0.37,1.89c-2.36,4.11-7.78,9.97-20.15,17.58"/>
 			<path id="kvg:08b72-s18" kvg:type="㇙" d="M56.59,78.2c0.73,0.73,1.16,1.93,1.16,3.31c0,7.77,0.04,11.91,0.04,13.22s0.78,2.06,1.77,1.08c0.99-0.99,10.25-8.29,11.57-9.27"/>
 			<path id="kvg:08b72-s19" kvg:type="㇒" d="M82.9,67.44c0.02,0.23-0.01,1.09-0.14,1.39c-0.86,1.87-3.32,4.78-7.72,8.49"/>

--- a/kanji/091b8-Kaisho.svg
+++ b/kanji/091b8-Kaisho.svg
@@ -52,41 +52,33 @@ kvg:type CDATA #IMPLIED >
 			<path id="kvg:091b8-Kaisho-s7" kvg:type="㇐a" d="M12.84,87.56c5.7-0.47,18.63-1.22,25.72-1.62"/>
 		</g>
 	</g>
-	<g id="kvg:091b8-Kaisho-g5" kvg:element="襄" kvg:variant="true" kvg:position="right">
+	<g id="kvg:091b8-Kaisho-g5" kvg:element="㐮" kvg:variant="true" kvg:original="襄" kvg:position="right">
 		<g id="kvg:091b8-Kaisho-g6" kvg:element="六" kvg:variant="true">
-			<g id="kvg:091b8-Kaisho-g7" kvg:element="衣" kvg:part="1">
-				<g id="kvg:091b8-Kaisho-g8" kvg:element="亠" kvg:position="top">
-					<path id="kvg:091b8-Kaisho-s8" kvg:type="㇔/㇑a" d="M61.36,11.25c2.29,0.79,5.64,3.9,6.08,5.43"/>
-					<path id="kvg:091b8-Kaisho-s9" kvg:type="㇐" d="M46.12,23.85c1.24,0.25,2.34,0.51,3.77,0.34c8.52-1.03,27.28-3.36,37.2-3.86c1.46-0.07,2.21,0.03,3.29,0.44"/>
-				</g>
+			<g id="kvg:091b8-Kaisho-g7" kvg:element="亠" kvg:position="top">
+				<path id="kvg:091b8-Kaisho-s8" kvg:type="㇔/㇑a" d="M61.36,11.25c2.29,0.79,5.64,3.9,6.08,5.43"/>
+				<path id="kvg:091b8-Kaisho-s9" kvg:type="㇐" d="M46.12,23.85c1.24,0.25,2.34,0.51,3.77,0.34c8.52-1.03,27.28-3.36,37.2-3.86c1.46-0.07,2.21,0.03,3.29,0.44"/>
 			</g>
-			<g id="kvg:091b8-Kaisho-g9" kvg:position="left">
-				<g id="kvg:091b8-Kaisho-g10" kvg:element="八">
-					<g id="kvg:091b8-Kaisho-g11" kvg:element="口" kvg:variant="true">
-						<path id="kvg:091b8-Kaisho-s10" kvg:type="㇒" d="M57.77,27.64c0.03,0.27,0.06,0.7-0.06,1.1c-0.71,2.31-4.81,7.38-10.41,10.48"/>
-					</g>
-				</g>
-				<g id="kvg:091b8-Kaisho-g12" kvg:element="口" kvg:variant="true" kvg:position="right">
-					<path id="kvg:091b8-Kaisho-s11" kvg:type="㇔" d="M76.77,26.33c4.43,1.3,11.44,5.36,12.54,7.38"/>
-				</g>
+			<g id="kvg:091b8-Kaisho-g8" kvg:element="八">
+				<path id="kvg:091b8-Kaisho-s10" kvg:type="㇒" d="M57.77,27.64c0.03,0.27,0.06,0.7-0.06,1.1c-0.71,2.31-4.81,7.38-10.41,10.48"/>
+				<path id="kvg:091b8-Kaisho-s11" kvg:type="㇔" d="M76.77,26.33c4.43,1.3,11.44,5.36,12.54,7.38"/>
 			</g>
 		</g>
-		<g id="kvg:091b8-Kaisho-g13" kvg:element="三" kvg:part="1">
-			<g id="kvg:091b8-Kaisho-g14" kvg:element="一" kvg:position="top">
+		<g id="kvg:091b8-Kaisho-g9" kvg:element="三" kvg:part="1">
+			<g id="kvg:091b8-Kaisho-g10" kvg:element="一" kvg:position="top">
 				<path id="kvg:091b8-Kaisho-s12" kvg:type="㇐" d="M50.75,43.52c0.71,0.29,3.52,0.35,4.24,0.29c6.51-0.56,20.76-2.81,27.77-3.45c1.18-0.11,1.9,0.14,2.5,0.28"/>
 			</g>
 		</g>
 		<path id="kvg:091b8-Kaisho-s13" kvg:type="㇑" d="M58.87,37.75c1.09,0.5,1.74,2.25,1.96,3.25c0.22,1,0,16.25-0.22,22.5"/>
 		<path id="kvg:091b8-Kaisho-s14" kvg:type="㇑" d="M75.87,33.75c0.88,1,1.72,2.24,1.46,3.75C76,45.25,76,52.5,75,61"/>
-		<g id="kvg:091b8-Kaisho-g15" kvg:element="三" kvg:part="1" kvg:position="bottom">
-			<g id="kvg:091b8-Kaisho-g16" kvg:element="一">
+		<g id="kvg:091b8-Kaisho-g11" kvg:element="三" kvg:part="1" kvg:position="bottom">
+			<g id="kvg:091b8-Kaisho-g12" kvg:element="一">
 				<path id="kvg:091b8-Kaisho-s15" kvg:type="㇐" d="M50.75,53.52c0.71,0.29,3.52,0.35,4.24,0.29c6.51-0.56,22.26-2.81,29.27-3.45c1.18-0.11,1.9,0.14,2.5,0.28"/>
 			</g>
-			<g id="kvg:091b8-Kaisho-g17" kvg:element="一">
+			<g id="kvg:091b8-Kaisho-g13" kvg:element="一">
 				<path id="kvg:091b8-Kaisho-s16" kvg:type="㇐" d="M45.25,63.89c0.94,0.38,2.66,0.42,3.6,0.38c7.4-0.27,38.07-3.73,42.61-3.38c1.56,0.12,2.5,0.18,3.29,0.37"/>
 			</g>
 		</g>
-		<g id="kvg:091b8-Kaisho-g18" kvg:element="衣" kvg:part="2" kvg:position="bottom">
+		<g id="kvg:091b8-Kaisho-g14" kvg:element="𧘇" kvg:position="bottom">
 			<path id="kvg:091b8-Kaisho-s17" kvg:type="㇒" d="M63.52,65.89c0.06,0.47,0.25,1.25-0.12,1.89c-2.36,4.11-10.06,11.6-21.9,18.08"/>
 			<path id="kvg:091b8-Kaisho-s18" kvg:type="㇙" d="M57.09,78.45c0.32,0.35,0.66,0.7,0.66,1.31c-0.02,7.77-0.21,14.16-0.21,15.47s0.78,2.06,1.77,1.08c0.99-0.99,10.5-8.79,11.82-9.77"/>
 			<path id="kvg:091b8-Kaisho-s19" kvg:type="㇒" d="M82.9,67.69c0.02,0.23,0.24,1.09,0.11,1.39c-0.86,1.87-3.57,4.53-7.97,8.24"/>

--- a/kanji/091b8-KaishoVtLst.svg
+++ b/kanji/091b8-KaishoVtLst.svg
@@ -52,41 +52,33 @@ kvg:type CDATA #IMPLIED >
 			<path id="kvg:091b8-KaishoVtLst-s7" kvg:type="㇐a" d="M12.84,87.56c5.7-0.47,18.63-1.22,25.72-1.62"/>
 		</g>
 	</g>
-	<g id="kvg:091b8-KaishoVtLst-g5" kvg:element="襄" kvg:variant="true" kvg:position="right">
+	<g id="kvg:091b8-KaishoVtLst-g5" kvg:element="㐮" kvg:variant="true" kvg:original="襄" kvg:position="right">
 		<g id="kvg:091b8-KaishoVtLst-g6" kvg:element="六" kvg:variant="true">
-			<g id="kvg:091b8-KaishoVtLst-g7" kvg:element="衣" kvg:part="1">
-				<g id="kvg:091b8-KaishoVtLst-g8" kvg:element="亠" kvg:position="top">
-					<path id="kvg:091b8-KaishoVtLst-s8" kvg:type="㇔/㇑a" d="M61.36,11.25c2.29,0.79,5.64,3.9,6.08,5.43"/>
-					<path id="kvg:091b8-KaishoVtLst-s9" kvg:type="㇐" d="M46.12,23.85c1.24,0.25,2.34,0.51,3.77,0.34c8.52-1.03,27.28-3.36,37.2-3.86c1.46-0.07,2.21,0.03,3.29,0.44"/>
-				</g>
+			<g id="kvg:091b8-KaishoVtLst-g7" kvg:element="亠" kvg:position="top">
+				<path id="kvg:091b8-KaishoVtLst-s8" kvg:type="㇔/㇑a" d="M61.36,11.25c2.29,0.79,5.64,3.9,6.08,5.43"/>
+				<path id="kvg:091b8-KaishoVtLst-s9" kvg:type="㇐" d="M46.12,23.85c1.24,0.25,2.34,0.51,3.77,0.34c8.52-1.03,27.28-3.36,37.2-3.86c1.46-0.07,2.21,0.03,3.29,0.44"/>
 			</g>
-			<g id="kvg:091b8-KaishoVtLst-g9" kvg:position="left">
-				<g id="kvg:091b8-KaishoVtLst-g10" kvg:element="八">
-					<g id="kvg:091b8-KaishoVtLst-g11" kvg:element="口" kvg:variant="true">
-						<path id="kvg:091b8-KaishoVtLst-s10" kvg:type="㇒" d="M57.77,27.64c0.03,0.27,0.06,0.7-0.06,1.1c-0.71,2.31-4.81,7.38-10.41,10.48"/>
-					</g>
-				</g>
-				<g id="kvg:091b8-KaishoVtLst-g12" kvg:element="口" kvg:variant="true" kvg:position="right">
-					<path id="kvg:091b8-KaishoVtLst-s11" kvg:type="㇔" d="M76.77,26.33c4.43,1.3,11.44,5.36,12.54,7.38"/>
-				</g>
+			<g id="kvg:091b8-KaishoVtLst-g8" kvg:element="八">
+				<path id="kvg:091b8-KaishoVtLst-s10" kvg:type="㇒" d="M57.77,27.64c0.03,0.27,0.06,0.7-0.06,1.1c-0.71,2.31-4.81,7.38-10.41,10.48"/>
+				<path id="kvg:091b8-KaishoVtLst-s11" kvg:type="㇔" d="M76.77,26.33c4.43,1.3,11.44,5.36,12.54,7.38"/>
 			</g>
 		</g>
-		<g id="kvg:091b8-KaishoVtLst-g13" kvg:element="三" kvg:part="1">
-			<g id="kvg:091b8-KaishoVtLst-g14" kvg:element="一" kvg:position="top">
+		<g id="kvg:091b8-KaishoVtLst-g9" kvg:element="三" kvg:part="1">
+			<g id="kvg:091b8-KaishoVtLst-g10" kvg:element="一" kvg:position="top">
 				<path id="kvg:091b8-KaishoVtLst-s12" kvg:type="㇐" d="M50.75,43.52c0.71,0.29,3.52,0.35,4.24,0.29c6.51-0.56,20.76-2.81,27.77-3.45c1.18-0.11,1.9,0.14,2.5,0.28"/>
 			</g>
 		</g>
-		<g id="kvg:091b8-KaishoVtLst-g15" kvg:element="三" kvg:part="1" kvg:position="bottom">
-			<g id="kvg:091b8-KaishoVtLst-g16" kvg:element="一">
+		<g id="kvg:091b8-KaishoVtLst-g11" kvg:element="三" kvg:part="1" kvg:position="bottom">
+			<g id="kvg:091b8-KaishoVtLst-g12" kvg:element="一">
 				<path id="kvg:091b8-KaishoVtLst-s13" kvg:type="㇐" d="M50.75,53.52c0.71,0.29,3.52,0.35,4.24,0.29c6.51-0.56,22.26-2.81,29.27-3.45c1.18-0.11,1.9,0.14,2.5,0.28"/>
 			</g>
-			<g id="kvg:091b8-KaishoVtLst-g17" kvg:element="一">
+			<g id="kvg:091b8-KaishoVtLst-g13" kvg:element="一">
 				<path id="kvg:091b8-KaishoVtLst-s14" kvg:type="㇐" d="M45.25,63.89c0.94,0.38,2.66,0.42,3.6,0.38c7.4-0.27,38.07-3.73,42.61-3.38c1.56,0.12,2.5,0.18,3.29,0.37"/>
 			</g>
 			<path id="kvg:091b8-KaishoVtLst-s15" kvg:type="㇑" d="M58.87,37.75c1.09,0.5,1.74,2.25,1.96,3.25c0.22,1,0,16.25-0.22,22.5"/>
 			<path id="kvg:091b8-KaishoVtLst-s16" kvg:type="㇑" d="M75.87,33.75c0.88,1,1.72,2.24,1.46,3.75C76,45.25,76,52.5,75,61"/>
 		</g>
-		<g id="kvg:091b8-KaishoVtLst-g18" kvg:element="衣" kvg:part="2" kvg:position="bottom">
+		<g id="kvg:091b8-KaishoVtLst-g14" kvg:element="𧘇" kvg:position="bottom">
 			<path id="kvg:091b8-KaishoVtLst-s17" kvg:type="㇒" d="M63.52,65.89c0.06,0.47,0.25,1.25-0.12,1.89c-2.36,4.11-10.06,11.6-21.9,18.08"/>
 			<path id="kvg:091b8-KaishoVtLst-s18" kvg:type="㇙" d="M57.09,78.45c0.32,0.35,0.66,0.7,0.66,1.31c-0.02,7.77-0.21,14.16-0.21,15.47s0.78,2.06,1.77,1.08c0.99-0.99,10.5-8.79,11.82-9.77"/>
 			<path id="kvg:091b8-KaishoVtLst-s19" kvg:type="㇒" d="M82.9,67.69c0.02,0.23,0.24,1.09,0.11,1.39c-0.86,1.87-3.57,4.53-7.97,8.24"/>

--- a/kanji/091b8.svg
+++ b/kanji/091b8.svg
@@ -52,37 +52,33 @@ kvg:type CDATA #IMPLIED >
 			<path id="kvg:091b8-s7" kvg:type="㇐a" d="M13.84,87.56c5.7-0.47,16.63-1.22,23.72-1.62"/>
 		</g>
 	</g>
-	<g id="kvg:091b8-g5" kvg:element="襄" kvg:variant="true" kvg:position="right" kvg:phon="襄V">
+	<g id="kvg:091b8-g5" kvg:element="㐮" kvg:variant="true" kvg:original="襄" kvg:position="right" kvg:phon="襄V">
 		<g id="kvg:091b8-g6" kvg:element="六" kvg:variant="true">
-			<g id="kvg:091b8-g7" kvg:element="衣" kvg:part="1">
-				<g id="kvg:091b8-g8" kvg:element="亠" kvg:position="top">
-					<path id="kvg:091b8-s8" kvg:type="㇑a" d="M64.39,11c1.05,1.05,1.35,2.25,1.35,3.59c0,2.77-0.09,4.41-0.09,6.93"/>
-					<path id="kvg:091b8-s9" kvg:type="㇐" d="M46.12,23.85c2.41,0.48,4.95,0.2,7.4-0.1c8.6-1.04,22.2-2.91,31.12-3.52c1.93-0.13,4.12-0.23,5.75,0.29"/>
-				</g>
+			<g id="kvg:091b8-g7" kvg:element="亠" kvg:position="top">
+				<path id="kvg:091b8-s8" kvg:type="㇑a" d="M64.39,11c1.05,1.05,1.35,2.25,1.35,3.59c0,2.77-0.09,4.41-0.09,6.93"/>
+				<path id="kvg:091b8-s9" kvg:type="㇐" d="M46.12,23.85c2.41,0.48,4.95,0.2,7.4-0.1c8.6-1.04,22.2-2.91,31.12-3.52c1.93-0.13,4.12-0.23,5.75,0.29"/>
 			</g>
-			<g id="kvg:091b8-g9" kvg:position="left">
-				<g id="kvg:091b8-g10" kvg:element="八">
-					<path id="kvg:091b8-s10" kvg:type="㇒" d="M57.52,27.14c0.09,0.73-0.07,1.41-0.46,2.03c-1.28,2.48-4.87,6.45-9.76,10.05"/>
-					<path id="kvg:091b8-s11" kvg:type="㇔" d="M75.75,26.5c4.96,1.27,12.82,5.24,14.06,7.22"/>
-				</g>
+			<g id="kvg:091b8-g8" kvg:element="八">
+				<path id="kvg:091b8-s10" kvg:type="㇒" d="M57.52,27.14c0.09,0.73-0.07,1.41-0.46,2.03c-1.28,2.48-4.87,6.45-9.76,10.05"/>
+				<path id="kvg:091b8-s11" kvg:type="㇔" d="M75.75,26.5c4.96,1.27,12.82,5.24,14.06,7.22"/>
 			</g>
 		</g>
-		<g id="kvg:091b8-g11" kvg:element="三" kvg:part="1">
-			<g id="kvg:091b8-g12" kvg:element="一" kvg:position="top">
+		<g id="kvg:091b8-g9" kvg:element="三" kvg:part="1">
+			<g id="kvg:091b8-g10" kvg:element="一" kvg:position="top">
 				<path id="kvg:091b8-s12" kvg:type="㇐" d="M51.75,42.77c1.78,0.72,4.45,0.53,6.27,0.35c6.95-0.69,18.4-2.18,24.73-2.76c1.18-0.11,1.9-0.11,2.5,0.03"/>
 			</g>
 		</g>
 		<path id="kvg:091b8-s13" kvg:type="㇑a" d="M59.12,37.5c1,1,1.46,2.38,1.46,4c0,1.02,0.03,13.75,0.03,21"/>
 		<path id="kvg:091b8-s14" kvg:type="㇑a" d="M75.87,33.25c0.88,1,1.09,2.47,0.96,4C76,46.88,75.62,50.25,75,61"/>
-		<g id="kvg:091b8-g13" kvg:element="三" kvg:part="1" kvg:position="bottom">
-			<g id="kvg:091b8-g14" kvg:element="一">
+		<g id="kvg:091b8-g11" kvg:element="三" kvg:part="1" kvg:position="bottom">
+			<g id="kvg:091b8-g12" kvg:element="一">
 				<path id="kvg:091b8-s15" kvg:type="㇐" d="M50,53.27c1.95,0.79,4.75,0.5,6.77,0.3c7.64-0.75,21.76-2.39,27.98-2.97c1.18-0.11,1.9-0.11,2.5,0.03"/>
 			</g>
-			<g id="kvg:091b8-g15" kvg:element="一">
+			<g id="kvg:091b8-g13" kvg:element="一">
 				<path id="kvg:091b8-s16" kvg:type="㇐" d="M45.25,63.89c2.38,0.74,4.88,0.68,7.01,0.42c10.15-1.21,28.32-2.79,36.1-3.14c2.09-0.09,4.34-0.16,6.39,0.34"/>
 			</g>
 		</g>
-		<g id="kvg:091b8-g16" kvg:element="衣" kvg:part="2" kvg:position="bottom">
+		<g id="kvg:091b8-g14" kvg:element="𧘇" kvg:position="bottom">
 			<path id="kvg:091b8-s17" kvg:type="㇒" d="M63.77,65.64c0.06,0.47,0.1,1.33-0.37,1.89c-4.03,4.72-11.9,11.59-20.9,16.58"/>
 			<path id="kvg:091b8-s18" kvg:type="㇙" d="M56.34,78.45c0.73,0.73,1.16,1.8,1.16,3.06c0,5.51,0.02,9.45,0.03,11.74c0.01,2.98,0.72,3.62,2.97,2c3.04-2.18,7.75-6.38,10.62-8.72"/>
 			<path id="kvg:091b8-s19" kvg:type="㇒" d="M83.15,67.69c0.02,0.23-0.18,1.14-0.39,1.39c-1.5,1.8-3.07,3.78-7.47,7.49"/>


### PR DESCRIPTION
https://github.com/KanjiVG/kanjivg/issues/253

This removes most of the extraneous groups, replaces the element 襄 with the correct element 㐮, keeping the old element under the kvg:original= field. It also replaces the bottom element 衣 with 𧘇 and removes some excessive groups.

The odd use of 三 for the middle part is not altered, however it seems to me that this should actually be ⿱井一. IDS seems to agree, giving this centre piece 𠀎 which it decomposes as I do.