### PR TITLE
Replace 僉 with 㑒, 幵 with 开

### DIFF
--- a/kanji/05039.svg
+++ b/kanji/05039.svg
@@ -41,7 +41,7 @@ kvg:type CDATA #IMPLIED >
 		<path id="kvg:05039-s1" kvg:type="㇒" d="M34.5,16.75c0.23,2.11-0.06,3.62-0.82,5.43C28.88,33.7,21.62,47.62,11,60.04"/>
 		<path id="kvg:05039-s2" kvg:type="㇑" d="M25.03,42.75c0.86,0.86,1.26,2.22,1.26,3.48c0,10.3,0.02,27.9,0.02,41.77c0,3.19-0.06,5.87-0.06,7.75"/>
 	</g>
-	<g id="kvg:05039-g2" kvg:element="僉" kvg:partial="true" kvg:position="right" kvg:phon="倹right/僉V">
+	<g id="kvg:05039-g2" kvg:element="㑒" kvg:original="僉" kvg:partial="true" kvg:position="right" kvg:phon="倹right/僉V">
 		<g id="kvg:05039-g3" kvg:element="人" kvg:position="top">
 			<path id="kvg:05039-s3" kvg:type="㇒" d="M60.85,13.25c0.28,1-0.1,2.26-0.66,3.41c-3.24,6.73-11.44,20.07-25.99,32.69"/>
 			<path id="kvg:05039-s4" kvg:type="㇏" d="M62,17.25c4.02,3.81,15.48,14.98,22.83,21.33c1.96,1.7,5.92,4.67,8.47,5.97"/>

--- a/kanji/05211.svg
+++ b/kanji/05211.svg
@@ -37,7 +37,7 @@ kvg:type CDATA #IMPLIED >
 <svg xmlns="http://www.w3.org/2000/svg" width="109" height="109" viewBox="0 0 109 109">
 <g id="kvg:StrokePaths_05211" style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;">
 <g id="kvg:05211" kvg:element="刑">
-	<g id="kvg:05211-g1" kvg:element="幵" kvg:partial="true" kvg:position="left" kvg:phon="井">
+	<g id="kvg:05211-g1" kvg:element="开" kvg:original="幵" kvg:partial="true" kvg:position="left" kvg:phon="井">
 		<g id="kvg:05211-g2" kvg:element="干">
 			<path id="kvg:05211-s1" kvg:type="㇐" d="M15.75,23.39c1.97,0.8,4.94,0.48,6.98,0.23c7.31-0.91,21.32-2.67,28.78-3.29c2.18-0.18,4.34-0.34,6.49,0.19"/>
 			<g id="kvg:05211-g3" kvg:element="十">

--- a/kanji/05263.svg
+++ b/kanji/05263.svg
@@ -37,7 +37,7 @@ kvg:type CDATA #IMPLIED >
 <svg xmlns="http://www.w3.org/2000/svg" width="109" height="109" viewBox="0 0 109 109">
 <g id="kvg:StrokePaths_05263" style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;">
 <g id="kvg:05263" kvg:element="剣">
-	<g id="kvg:05263-g1" kvg:element="僉" kvg:partial="true" kvg:position="left" kvg:phon="僉V">
+	<g id="kvg:05263-g1" kvg:element="㑒" kvg:original="僉" kvg:partial="true" kvg:position="left" kvg:phon="僉V">
 		<g id="kvg:05263-g2" kvg:element="人" kvg:variant="true" kvg:position="top">
 			<path id="kvg:05263-s1" kvg:type="㇒" d="M40.85,16c0.28,1-0.1,2.51-0.66,3.66c-3.24,6.73-12.19,20.32-26.74,32.94"/>
 			<path id="kvg:05263-s2" kvg:type="㇔/㇏" d="M43,22.12c5.32,2.16,11.29,6.92,14.3,10.86"/>

--- a/kanji/05271.svg
+++ b/kanji/05271.svg
@@ -37,7 +37,7 @@ kvg:type CDATA #IMPLIED >
 <svg xmlns="http://www.w3.org/2000/svg" width="109" height="109" viewBox="0 0 109 109">
 <g id="kvg:StrokePaths_05271" style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;">
 <g id="kvg:05271" kvg:element="剱">
-	<g id="kvg:05271-g1" kvg:element="僉" kvg:partial="true" kvg:position="left">
+	<g id="kvg:05271-g1" kvg:element="㑒" kvg:original="僉" kvg:partial="true" kvg:position="left">
 		<g id="kvg:05271-g2" kvg:element="人" kvg:position="top">
 			<path id="kvg:05271-s1" kvg:type="㇒" d="M34.6,14c0.08,0.8,0.31,2.1-0.16,3.22C31.25,25,24,38.25,8.21,49.1"/>
 			<path id="kvg:05271-s2" kvg:type="㇔/㇏" d="M35.78,20.05c6.05,2.43,13.59,8.26,17.03,12.69"/>

--- a/kanji/0578b.svg
+++ b/kanji/0578b.svg
@@ -38,7 +38,7 @@ kvg:type CDATA #IMPLIED >
 <g id="kvg:StrokePaths_0578b" style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;">
 <g id="kvg:0578b" kvg:element="型">
 	<g id="kvg:0578b-g1" kvg:element="刑" kvg:position="top" kvg:phon="刑">
-		<g id="kvg:0578b-g2" kvg:element="幵" kvg:partial="true">
+		<g id="kvg:0578b-g2" kvg:element="开" kvg:original="幵" kvg:partial="true">
 			<g id="kvg:0578b-g3" kvg:element="干">
 				<path id="kvg:0578b-s1" kvg:type="㇐" d="M17.54,22.38c1.11,0.38,3.15,0.44,4.27,0.38c8.24-0.43,18.19-1.89,26.67-2.98c1.84-0.24,2.97-0.07,3.9,0.12"/>
 				<g id="kvg:0578b-g4" kvg:element="十">

--- a/kanji/0598d.svg
+++ b/kanji/0598d.svg
@@ -42,7 +42,7 @@ kvg:type CDATA #IMPLIED >
 		<path id="kvg:0598d-s2" kvg:type="㇒" d="M39.75,36.89c0.08,1.27,0.14,4.34-0.16,6.18C37.18,57.91,31,79.75,13,90"/>
 		<path id="kvg:0598d-s3" kvg:type="㇀/㇐" d="M8.5,47.22c0.75,0.94,1.75,1.62,3.75,1.39c2.15-0.24,21.34-4.85,30.25-7.23"/>
 	</g>
-	<g id="kvg:0598d-g2" kvg:element="幵" kvg:partial="true" kvg:position="right">
+	<g id="kvg:0598d-g2" kvg:element="开" kvg:original="幵" kvg:partial="true" kvg:position="right">
 		<g id="kvg:0598d-g3" kvg:element="干">
 			<path id="kvg:0598d-s4" kvg:type="㇐" d="M48.08,20.39c1.22,0.45,3.44,0.5,4.66,0.45c7.31-0.32,24.65-3.56,35.6-3.4c2.03,0.03,3.24,0.21,4.25,0.44"/>
 			<g id="kvg:0598d-g4" kvg:element="十">

--- a/kanji/05f62.svg
+++ b/kanji/05f62.svg
@@ -37,7 +37,7 @@ kvg:type CDATA #IMPLIED >
 <svg xmlns="http://www.w3.org/2000/svg" width="109" height="109" viewBox="0 0 109 109">
 <g id="kvg:StrokePaths_05f62" style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;">
 <g id="kvg:05f62" kvg:element="形">
-	<g id="kvg:05f62-g1" kvg:element="幵" kvg:partial="true" kvg:position="left" kvg:phon="幵">
+	<g id="kvg:05f62-g1" kvg:element="开" kvg:original="幵" kvg:partial="true" kvg:position="left" kvg:phon="幵">
 		<g id="kvg:05f62-g2" kvg:element="干">
 			<path id="kvg:05f62-s1" kvg:type="㇐" d="M19.63,23.42c1.2,0.38,3.39,0.46,4.59,0.38c4.66-0.3,16.61-2.55,25.33-3.88c1.96-0.3,3.83-0.32,4.83-0.13"/>
 			<g id="kvg:05f62-g3" kvg:element="十">

--- a/kanji/06785-Kaisho.svg
+++ b/kanji/06785-Kaisho.svg
@@ -43,7 +43,7 @@ kvg:type CDATA #IMPLIED >
 		<path id="kvg:06785-Kaisho-s3" kvg:type="㇒" d="M30.94,39.28c-5.9,16.34-9.19,23.25-18.33,37.56"/>
 		<path id="kvg:06785-Kaisho-s4" kvg:type="㇔/㇏" d="M33.97,46.15c2.23,1.71,5.9,7.28,7.78,10.6"/>
 	</g>
-	<g id="kvg:06785-Kaisho-g2" kvg:element="幵" kvg:partial="true" kvg:position="right">
+	<g id="kvg:06785-Kaisho-g2" kvg:element="开" kvg:original="幵" kvg:partial="true" kvg:position="right">
 		<g id="kvg:06785-Kaisho-g3" kvg:element="干">
 			<path id="kvg:06785-Kaisho-s5" kvg:type="㇐" d="M48.5,21.8c1.05,0.39,2.98,0.44,4.04,0.39c6.34-0.28,26.46-1.94,36.02-2.98c1.75-0.19,2.81,0.19,3.69,0.39"/>
 			<g id="kvg:06785-Kaisho-g4" kvg:element="十">

--- a/kanji/06785.svg
+++ b/kanji/06785.svg
@@ -43,7 +43,7 @@ kvg:type CDATA #IMPLIED >
 		<path id="kvg:06785-s3" kvg:type="㇒" d="M30.94,39.28c-5.9,16.34-9.19,23.25-18.33,37.56"/>
 		<path id="kvg:06785-s4" kvg:type="㇔/㇏" d="M33.97,46.15c2.23,1.71,5.9,7.28,7.78,10.6"/>
 	</g>
-	<g id="kvg:06785-g2" kvg:element="幵" kvg:partial="true" kvg:position="right">
+	<g id="kvg:06785-g2" kvg:element="开" kvg:original="幵" kvg:partial="true" kvg:position="right">
 		<g id="kvg:06785-g3" kvg:element="干">
 			<path id="kvg:06785-s5" kvg:type="㇐" d="M48.5,21.8c1.05,0.39,2.98,0.44,4.04,0.39c6.34-0.28,26.46-1.94,36.02-2.98c1.75-0.19,2.81,0.19,3.69,0.39"/>
 			<g id="kvg:06785-g4" kvg:element="十">

--- a/kanji/0691c-Kaisho.svg
+++ b/kanji/0691c-Kaisho.svg
@@ -43,7 +43,7 @@ kvg:type CDATA #IMPLIED >
 		<path id="kvg:0691c-Kaisho-s3" kvg:type="㇒" d="M29.56,38.67c-6.24,14.54-9.71,20.69-19.38,33.41"/>
 		<path id="kvg:0691c-Kaisho-s4" kvg:type="㇔/㇏" d="M32.05,45.17c2.42,1.88,6.41,7.96,8.46,11.6"/>
 	</g>
-	<g id="kvg:0691c-Kaisho-g2" kvg:element="僉" kvg:partial="true" kvg:position="right">
+	<g id="kvg:0691c-Kaisho-g2" kvg:element="㑒" kvg:original="僉" kvg:partial="true" kvg:position="right">
 		<g id="kvg:0691c-Kaisho-g3" kvg:element="人" kvg:position="top">
 			<path id="kvg:0691c-Kaisho-s5" kvg:type="㇒" d="M64.62,9.75c0.07,0.79,0.33,2.12-0.13,3.19c-2.74,6.31-11.24,21.31-23.54,30.56"/>
 			<path id="kvg:0691c-Kaisho-s6" kvg:type="㇏" d="M64.28,14.38C69,19.25,87.33,37.06,91.81,40.78c1.52,1.26,3.47,1.8,4.99,2.16"/>

--- a/kanji/0691c.svg
+++ b/kanji/0691c.svg
@@ -43,7 +43,7 @@ kvg:type CDATA #IMPLIED >
 		<path id="kvg:0691c-s3" kvg:type="㇒" d="M28.81,38.42c0,1.45-0.48,3.01-0.94,4.07c-5.39,12.24-9.04,18.38-17.93,30.09"/>
 		<path id="kvg:0691c-s4" kvg:type="㇔/㇏" d="M32.62,45.62c2.19,1.84,5.78,7.82,7.63,11.39"/>
 	</g>
-	<g id="kvg:0691c-g2" kvg:element="僉" kvg:partial="true" kvg:position="right" kvg:phon="僉V">
+	<g id="kvg:0691c-g2" kvg:element="㑒" kvg:original="僉" kvg:partial="true" kvg:position="right" kvg:phon="僉V">
 		<g id="kvg:0691c-g3" kvg:element="人" kvg:position="top">
 			<path id="kvg:0691c-s5" kvg:type="㇒" d="M64.87,9.75c0.07,0.79,0.08,1.87-0.38,2.94C61.75,19,53.25,34.25,40.96,43.5"/>
 			<path id="kvg:0691c-s6" kvg:type="㇏" d="M64.78,14.88c5.47,4.37,16.81,16.59,23.76,22.98c2.2,2.03,4.29,3.27,6.76,4.83"/>

--- a/kanji/07814.svg
+++ b/kanji/07814.svg
@@ -46,7 +46,7 @@ kvg:type CDATA #IMPLIED >
 			<path id="kvg:07814-s5" kvg:type="㇐b" d="M26.25,76c3.38-0.5,8.87-1.69,13.89-2.39c1.36-0.19,2.6-0.32,3.61-0.36"/>
 		</g>
 	</g>
-	<g id="kvg:07814-g3" kvg:element="幵" kvg:partial="true" kvg:position="right" kvg:phon="幵">
+	<g id="kvg:07814-g3" kvg:element="开" kvg:original="幵" kvg:partial="true" kvg:position="right" kvg:phon="幵">
 		<g id="kvg:07814-g4" kvg:element="干">
 			<path id="kvg:07814-s6" kvg:type="㇐" d="M52,20.89c2.25,0.61,4.46,0.37,6.38,0.18c6.76-0.67,19.24-2.07,27.87-2.91c1.83-0.18,3.71-0.09,5.5,0.35"/>
 			<g id="kvg:07814-g5" kvg:element="十">

--- a/kanji/07b04.svg
+++ b/kanji/07b04.svg
@@ -49,7 +49,7 @@ kvg:type CDATA #IMPLIED >
 			<path id="kvg:07b04-s6" kvg:type="㇒/㇚" d="M77.54,23.11c0.02,0.25,0.05,0.65-0.05,1.01c-0.58,2.12-3.92,6.78-8.49,9.63"/>
 		</g>
 	</g>
-	<g id="kvg:07b04-g4" kvg:element="幵" kvg:partial="true" kvg:position="bottom">
+	<g id="kvg:07b04-g4" kvg:element="开" kvg:original="幵" kvg:partial="true" kvg:position="bottom">
 		<g id="kvg:07b04-g5" kvg:element="干">
 			<path id="kvg:07b04-s7" kvg:type="㇐" d="M23.25,43.24c1.5,0.45,4.24,0.5,5.75,0.45c9.02-0.32,37.75-3.05,51.26-2.88c2.5,0.03,4,0.21,5.25,0.44"/>
 			<g id="kvg:07b04-g6" kvg:element="十">

--- a/kanji/0834a.svg
+++ b/kanji/0834a.svg
@@ -43,7 +43,7 @@ kvg:type CDATA #IMPLIED >
 		<path id="kvg:0834a-s3" kvg:type="㇑a" d="M70.75,9.5c0.42,1.18,0.34,2.77,0,4.25c-1.25,5.5-2.12,9.62-3.5,15.75"/>
 	</g>
 	<g id="kvg:0834a-g2" kvg:element="刑" kvg:position="bottom">
-		<g id="kvg:0834a-g3" kvg:element="幵" kvg:partial="true">
+		<g id="kvg:0834a-g3" kvg:element="开" kvg:original="幵" kvg:partial="true">
 			<g id="kvg:0834a-g4" kvg:element="干">
 				<path id="kvg:0834a-s4" kvg:type="㇐" d="M20.82,40c2.4,0.39,4.79,0.38,7.21,0.11c6.47-0.73,15.65-2.08,21.59-2.53c2.16-0.3,4.31-0.26,6.45,0.12"/>
 				<g id="kvg:0834a-g5" kvg:element="十">

--- a/kanji/0958b-Kaisho.svg
+++ b/kanji/0958b-Kaisho.svg
@@ -51,7 +51,7 @@ kvg:type CDATA #IMPLIED >
 			<path id="kvg:0958b-Kaisho-s8" kvg:type="㇐a" d="M65.05,36.76c4.99,0,16.59-2.06,23.05-2.06"/>
 		</g>
 	</g>
-	<g id="kvg:0958b-Kaisho-g4" kvg:element="幵" kvg:partial="true">
+	<g id="kvg:0958b-Kaisho-g4" kvg:element="开" kvg:original="幵" kvg:partial="true">
 		<g id="kvg:0958b-Kaisho-g5" kvg:element="干">
 			<path id="kvg:0958b-Kaisho-s9" kvg:type="㇐" d="M37.13,51.67c0.94,0.38,2.67,0.52,3.6,0.38c8.77-1.3,16.77-2.8,26.36-3.38c1.56-0.1,2.5,0.18,3.29,0.37"/>
 			<g id="kvg:0958b-Kaisho-g6" kvg:element="十">

--- a/kanji/0958b.svg
+++ b/kanji/0958b.svg
@@ -51,7 +51,7 @@ kvg:type CDATA #IMPLIED >
 			<path id="kvg:0958b-s8" kvg:type="㇐a" d="M65.05,36.01c6.57-0.51,16.2-1.51,23.3-1.81"/>
 		</g>
 	</g>
-	<g id="kvg:0958b-g4" kvg:element="幵" kvg:partial="true">
+	<g id="kvg:0958b-g4" kvg:element="开" kvg:original="幵" kvg:partial="true">
 		<g id="kvg:0958b-g5" kvg:element="干">
 			<path id="kvg:0958b-s9" kvg:type="㇐" d="M35.63,51.67c2.25,0.46,4.51,0.09,6.76-0.14c5.36-0.53,16.39-1.77,23-2.46c1.92-0.2,3.82-0.4,5.74-0.04"/>
 			<g id="kvg:0958b-g6" kvg:element="十">

--- a/kanji/0967a.svg
+++ b/kanji/0967a.svg
@@ -42,7 +42,7 @@ kvg:type CDATA #IMPLIED >
 		<path id="kvg:0967a-s2" kvg:type="㇕va" d="M25.5,35.58c14.25,7.17,11.88,32.3,0.67,26"/>
 		<path id="kvg:0967a-s3" kvg:type="㇑" d="M15.37,20.37c0.69,0.69,0.96,1.75,0.96,2.53c0,0.81,0.02,47.42,0.03,66.35c0,3.31,0,5.77,0,7"/>
 	</g>
-	<g id="kvg:0967a-g2" kvg:element="僉" kvg:partial="true" kvg:position="right" kvg:phon="僉V">
+	<g id="kvg:0967a-g2" kvg:element="㑒" kvg:original="僉" kvg:partial="true" kvg:position="right" kvg:phon="僉V">
 		<g id="kvg:0967a-g3" kvg:element="人" kvg:position="top">
 			<path id="kvg:0967a-s4" kvg:type="㇒" d="M62.87,10.75c0.07,0.78,0.08,1.83-0.38,2.88C59.75,19.82,53.25,33,40.96,44.6"/>
 			<path id="kvg:0967a-s5" kvg:type="㇏" d="M61.78,16.3c4.85,3.58,18.01,15.32,24.71,21.22c2.15,1.89,4.21,3.55,6.81,4.79"/>

--- a/kanji/09a13-Vt6.svg
+++ b/kanji/09a13-Vt6.svg
@@ -51,7 +51,7 @@ kvg:type CDATA #IMPLIED >
 			<path id="kvg:09a13-Vt6-s10" kvg:type="㇔" d="M31.54,65.5c1.3,1.79,3.45,3.63,3.91,6"/>
 		</g>
 	</g>
-	<g id="kvg:09a13-Vt6-g3" kvg:element="僉" kvg:partial="true" kvg:position="right">
+	<g id="kvg:09a13-Vt6-g3" kvg:element="㑒" kvg:original="僉" kvg:partial="true" kvg:position="right">
 		<g id="kvg:09a13-Vt6-g4" kvg:element="人" kvg:position="top">
 			<path id="kvg:09a13-Vt6-s11" kvg:type="㇒" d="M65.99,11.25c0.06,0.71,0.26,1.88-0.11,2.86C63.25,21,56.5,33,46.15,41.5"/>
 			<path id="kvg:09a13-Vt6-s12" kvg:type="㇏" d="M66.9,14.12c3.23,4.66,20.16,19.87,23.73,23.28c1.21,1.16,2.76,1.65,3.97,1.98"/>

--- a/kanji/09a13.svg
+++ b/kanji/09a13.svg
@@ -51,7 +51,7 @@ kvg:type CDATA #IMPLIED >
 			<path id="kvg:09a13-s10" kvg:type="㇔" d="M30.5,64.5c1.75,1.75,4.36,4.24,4.96,7"/>
 		</g>
 	</g>
-	<g id="kvg:09a13-g3" kvg:element="僉" kvg:partial="true" kvg:position="right" kvg:phon="僉V">
+	<g id="kvg:09a13-g3" kvg:element="㑒" kvg:original="僉" kvg:partial="true" kvg:position="right" kvg:phon="僉V">
 		<g id="kvg:09a13-g4" kvg:element="人" kvg:position="top">
 			<path id="kvg:09a13-s11" kvg:type="㇒" d="M66.48,11.5c0.06,0.71,0.27,1.89-0.11,2.87c-2.69,6.92-9.61,18.97-20.22,27.5"/>
 			<path id="kvg:09a13-s12" kvg:type="㇏" d="M66.9,14.12c2.71,4.05,15.43,16.09,20.95,21.39c1.79,1.73,3.39,3.23,5.77,3.86"/>

--- a/kanji/09e78.svg
+++ b/kanji/09e78.svg
@@ -58,7 +58,7 @@ kvg:type CDATA #IMPLIED >
 			</g>
 		</g>
 	</g>
-	<g id="kvg:09e78-g6" kvg:element="僉" kvg:partial="true" kvg:position="right">
+	<g id="kvg:09e78-g6" kvg:element="㑒" kvg:original="僉" kvg:partial="true" kvg:position="right">
 		<g id="kvg:09e78-g7" kvg:element="人" kvg:position="top">
 			<path id="kvg:09e78-s12" kvg:type="㇒" d="M68.74,12.25c0.05,0.76,0.09,2.04-0.36,3.05C64.75,23.5,59.38,34,49.9,43.75"/>
 			<path id="kvg:09e78-s13" kvg:type="㇏" d="M70.62,17.25C73.83,21.17,81,29.38,86.42,34.59c2.82,2.71,5.15,5.29,8.69,6.79"/>


### PR DESCRIPTION
The replaced elements are kept under the kvg:original field.

https://github.com/KanjiVG/kanjivg/issues/251