### PR TITLE
Fix wrong stroke types on 曲 elements

### DIFF
--- a/kanji/066f9-KaishoVtLst.svg
+++ b/kanji/066f9-KaishoVtLst.svg
@@ -47,16 +47,16 @@ kvg:type CDATA #IMPLIED >
 			<g id="kvg:066f9-KaishoVtLst-g4" kvg:element="廾" kvg:variant="true">
 				<g id="kvg:066f9-KaishoVtLst-g5" kvg:element="丿" kvg:variant="true">
 					<g id="kvg:066f9-KaishoVtLst-g6" kvg:element="十" kvg:part="1">
-						<path id="kvg:066f9-KaishoVtLst-s4" kvg:type="㇑" d="M28.44,46.98c12.36-0.88,24.7-1.99,37.05-2.96c1.42-0.11,2.8-0.22,4.12-0.32"/>
+						<path id="kvg:066f9-KaishoVtLst-s4" kvg:type="㇐" d="M28.44,46.98c12.36-0.88,24.7-1.99,37.05-2.96c1.42-0.11,2.8-0.22,4.12-0.32"/>
 					</g>
 				</g>
-				<path id="kvg:066f9-KaishoVtLst-s5" kvg:type="㇑" d="M31.83,58.68c6.6-0.4,38.48-3.04,46.7-3.38"/>
+				<path id="kvg:066f9-KaishoVtLst-s5" kvg:type="㇐" d="M31.83,58.68c6.6-0.4,38.48-3.04,46.7-3.38"/>
 				<g id="kvg:066f9-KaishoVtLst-g7" kvg:element="日" kvg:part="2">
 					<g id="kvg:066f9-KaishoVtLst-g8" kvg:element="十" kvg:part="2">
-						<path id="kvg:066f9-KaishoVtLst-s6" kvg:type="㇐" d="M40.89,13.27c0.85,0.39,1.47,1.75,1.53,2.54c1.33,17.68,3.11,33.8,3.7,41.04"/>
+						<path id="kvg:066f9-KaishoVtLst-s6" kvg:type="㇑" d="M40.89,13.27c0.85,0.39,1.47,1.75,1.53,2.54c1.33,17.68,3.11,33.8,3.7,41.04"/>
 					</g>
 				</g>
-				<path id="kvg:066f9-KaishoVtLst-s7" kvg:type="㇐" d="M63.31,10.25c0.85,0.39,1.59,1.75,1.53,2.54c-1.63,23.68-1.8,26.64-2.97,43.08"/>
+				<path id="kvg:066f9-KaishoVtLst-s7" kvg:type="㇑" d="M63.31,10.25c0.85,0.39,1.59,1.75,1.53,2.54c-1.63,23.68-1.8,26.64-2.97,43.08"/>
 			</g>
 		</g>
 	</g>

--- a/kanji/069fd-KaishoVtLst.svg
+++ b/kanji/069fd-KaishoVtLst.svg
@@ -54,16 +54,16 @@ kvg:type CDATA #IMPLIED >
 				<g id="kvg:069fd-KaishoVtLst-g6" kvg:element="廾" kvg:variant="true">
 					<g id="kvg:069fd-KaishoVtLst-g7" kvg:element="丿" kvg:variant="true">
 						<g id="kvg:069fd-KaishoVtLst-g8" kvg:element="十" kvg:part="1">
-							<path id="kvg:069fd-KaishoVtLst-s8" kvg:type="㇑" d="M50.09,46.54c9.13-0.84,18.23-1.92,27.35-2.84c1.05-0.11,4.07-0.21,5.04-0.31"/>
+							<path id="kvg:069fd-KaishoVtLst-s8" kvg:type="㇐" d="M50.09,46.54c9.13-0.84,18.23-1.92,27.35-2.84c1.05-0.11,4.07-0.21,5.04-0.31"/>
 						</g>
 					</g>
-					<path id="kvg:069fd-KaishoVtLst-s9" kvg:type="㇑" d="M52.6,57.29c4.87-0.38,28.41-2.42,34.48-2.75"/>
+					<path id="kvg:069fd-KaishoVtLst-s9" kvg:type="㇐" d="M52.6,57.29c4.87-0.38,28.41-2.42,34.48-2.75"/>
 					<g id="kvg:069fd-KaishoVtLst-g9" kvg:element="日" kvg:part="2">
 						<g id="kvg:069fd-KaishoVtLst-g10" kvg:element="十" kvg:part="2">
-							<path id="kvg:069fd-KaishoVtLst-s10" kvg:type="㇐" d="M59.29,14.15c0.63,0.38,1.09,1.68,1.13,2.45c0.98,16.99,2.3,32.47,2.73,39.43"/>
+							<path id="kvg:069fd-KaishoVtLst-s10" kvg:type="㇑" d="M59.29,14.15c0.63,0.38,1.09,1.68,1.13,2.45c0.98,16.99,2.3,32.47,2.73,39.43"/>
 						</g>
 					</g>
-					<path id="kvg:069fd-KaishoVtLst-s11" kvg:type="㇐" d="M75.84,11.25c0.63,0.38,1.17,1.68,1.13,2.44c-1.2,22.76-1.33,25.6-2.19,41.4"/>
+					<path id="kvg:069fd-KaishoVtLst-s11" kvg:type="㇑" d="M75.84,11.25c0.63,0.38,1.17,1.68,1.13,2.44c-1.2,22.76-1.33,25.6-2.19,41.4"/>
 				</g>
 			</g>
 		</g>

--- a/kanji/06f15-KaishoVtLst.svg
+++ b/kanji/06f15-KaishoVtLst.svg
@@ -53,16 +53,16 @@ kvg:type CDATA #IMPLIED >
 				<g id="kvg:06f15-KaishoVtLst-g6" kvg:element="廾" kvg:variant="true">
 					<g id="kvg:06f15-KaishoVtLst-g7" kvg:element="丿" kvg:variant="true">
 						<g id="kvg:06f15-KaishoVtLst-g8" kvg:element="十" kvg:part="1">
-							<path id="kvg:06f15-KaishoVtLst-s7" kvg:type="㇑" d="M44.15,45.54c10.16-0.84,20.35-1.49,30.53-2.16c1.17-0.08,3.81-0.15,4.9-0.22"/>
+							<path id="kvg:06f15-KaishoVtLst-s7" kvg:type="㇐" d="M44.15,45.54c10.16-0.84,20.35-1.49,30.53-2.16c1.17-0.08,3.81-0.15,4.9-0.22"/>
 						</g>
 					</g>
-					<path id="kvg:06f15-KaishoVtLst-s8" kvg:type="㇑" d="M47.41,56.29c5.38-0.38,31.35-2.42,38.05-2.75"/>
+					<path id="kvg:06f15-KaishoVtLst-s8" kvg:type="㇐" d="M47.41,56.29c5.38-0.38,31.35-2.42,38.05-2.75"/>
 					<g id="kvg:06f15-KaishoVtLst-g9" kvg:element="日" kvg:part="2">
 						<g id="kvg:06f15-KaishoVtLst-g10" kvg:element="十" kvg:part="2">
-							<path id="kvg:06f15-KaishoVtLst-s9" kvg:type="㇐" d="M54.8,13.15c0.69,0.38,1.2,1.68,1.25,2.45c1.08,16.99,2.54,32.47,3.01,39.43"/>
+							<path id="kvg:06f15-KaishoVtLst-s9" kvg:type="㇑" d="M54.8,13.15c0.69,0.38,1.2,1.68,1.25,2.45c1.08,16.99,2.54,32.47,3.01,39.43"/>
 						</g>
 					</g>
-					<path id="kvg:06f15-KaishoVtLst-s10" kvg:type="㇐" d="M73.06,10.25c0.69,0.38,1.29,1.68,1.25,2.44c-1.33,22.76-1.47,25.6-2.42,41.4"/>
+					<path id="kvg:06f15-KaishoVtLst-s10" kvg:type="㇑" d="M73.06,10.25c0.69,0.38,1.29,1.68,1.25,2.44c-1.33,22.76-1.47,25.6-2.42,41.4"/>
 				</g>
 			</g>
 		</g>

--- a/kanji/079ae-Kaisho.svg
+++ b/kanji/079ae-Kaisho.svg
@@ -56,7 +56,7 @@ kvg:type CDATA #IMPLIED >
 			</g>
 			<g id="kvg:079ae-Kaisho-g7" kvg:element="廾">
 				<g id="kvg:079ae-Kaisho-g8" kvg:element="十" kvg:part="1">
-					<path id="kvg:079ae-Kaisho-s8" kvg:type="㇐" d="M60.25,13.75c0.71,0.28,1.57,2,1.59,2.46c0.45,10.3,1.56,24.12,1.77,28.35"/>
+					<path id="kvg:079ae-Kaisho-s8" kvg:type="㇑" d="M60.25,13.75c0.71,0.28,1.57,2,1.59,2.46c0.45,10.3,1.56,24.12,1.77,28.35"/>
 				</g>
 				<g id="kvg:079ae-Kaisho-g9" kvg:element="丿" kvg:variant="true">
 					<path id="kvg:079ae-Kaisho-s9" kvg:type="㇑" d="M75.93,11.49c0.7,0.21,1.33,1,1.31,1.48c-0.74,14.32-0.93,20.97-1.48,30.91"/>

--- a/kanji/079ae-KaishoVtLst.svg
+++ b/kanji/079ae-KaishoVtLst.svg
@@ -59,14 +59,14 @@ kvg:type CDATA #IMPLIED >
 					<path id="kvg:079ae-KaishoVtLst-s8" kvg:type="㇐" d="M51.47,35.1c8.61-0.23,17.28-1.37,25.86-2.08c1.07-0.09,3.61-0.17,4.61-0.25"/>
 				</g>
 				<g id="kvg:079ae-KaishoVtLst-g9" kvg:element="丿" kvg:variant="true">
-					<path id="kvg:079ae-KaishoVtLst-s9" kvg:type="㇑" d="M53.62,46.4c4.8-0.32,27.93-2.08,33.91-2.36"/>
+					<path id="kvg:079ae-KaishoVtLst-s9" kvg:type="㇐" d="M53.62,46.4c4.8-0.32,27.93-2.08,33.91-2.36"/>
 				</g>
 				<g id="kvg:079ae-KaishoVtLst-g10" kvg:element="十" kvg:part="2">
 					<path id="kvg:079ae-KaishoVtLst-s10" kvg:type="㇑" d="M60.25,13.75c0.71,0.28,1.57,2,1.59,2.46c0.45,10.3,1.56,24.12,1.77,28.35"/>
 				</g>
 			</g>
 			<g id="kvg:079ae-KaishoVtLst-g11" kvg:element="日" kvg:part="2">
-				<path id="kvg:079ae-KaishoVtLst-s11" kvg:type="㇐" d="M75.93,11.49c0.7,0.21,1.33,1,1.31,1.48c-0.74,14.32-0.93,20.97-1.48,30.91"/>
+				<path id="kvg:079ae-KaishoVtLst-s11" kvg:type="㇑" d="M75.93,11.49c0.7,0.21,1.33,1,1.31,1.48c-0.74,14.32-0.93,20.97-1.48,30.91"/>
 			</g>
 		</g>
 		<g id="kvg:079ae-KaishoVtLst-g12" kvg:element="豆" kvg:position="bottom">

--- a/kanji/07cdf-KaishoVtLst.svg
+++ b/kanji/07cdf-KaishoVtLst.svg
@@ -56,16 +56,16 @@ kvg:type CDATA #IMPLIED >
 				<g id="kvg:07cdf-KaishoVtLst-g6" kvg:element="廾" kvg:variant="true">
 					<g id="kvg:07cdf-KaishoVtLst-g7" kvg:element="丿" kvg:variant="true">
 						<g id="kvg:07cdf-KaishoVtLst-g8" kvg:element="十" kvg:part="1">
-							<path id="kvg:07cdf-KaishoVtLst-s10" kvg:type="㇑" d="M52.59,46.54c9.13-0.84,18.24-1.92,27.35-2.84c1.05-0.11,4.07-0.21,5.04-0.31"/>
+							<path id="kvg:07cdf-KaishoVtLst-s10" kvg:type="㇐" d="M52.59,46.54c9.13-0.84,18.24-1.92,27.35-2.84c1.05-0.11,4.07-0.21,5.04-0.31"/>
 						</g>
 					</g>
-					<path id="kvg:07cdf-KaishoVtLst-s11" kvg:type="㇑" d="M55.1,56.79c4.87-0.38,28.41-2.42,34.48-2.75"/>
+					<path id="kvg:07cdf-KaishoVtLst-s11" kvg:type="㇐" d="M55.1,56.79c4.87-0.38,28.41-2.42,34.48-2.75"/>
 					<g id="kvg:07cdf-KaishoVtLst-g9" kvg:element="日" kvg:part="2">
 						<g id="kvg:07cdf-KaishoVtLst-g10" kvg:element="十" kvg:part="2">
-							<path id="kvg:07cdf-KaishoVtLst-s12" kvg:type="㇐" d="M61.29,14.15c0.63,0.38,1.09,1.68,1.13,2.45c0.98,16.99,2.3,32.47,2.73,39.43"/>
+							<path id="kvg:07cdf-KaishoVtLst-s12" kvg:type="㇑" d="M61.29,14.15c0.63,0.38,1.09,1.68,1.13,2.45c0.98,16.99,2.3,32.47,2.73,39.43"/>
 						</g>
 					</g>
-					<path id="kvg:07cdf-KaishoVtLst-s13" kvg:type="㇐" d="M78.34,11.75c0.63,0.38,1.17,1.68,1.13,2.44c-1.2,22.76-1.33,25.1-2.19,40.9"/>
+					<path id="kvg:07cdf-KaishoVtLst-s13" kvg:type="㇑" d="M78.34,11.75c0.63,0.38,1.17,1.68,1.13,2.44c-1.2,22.76-1.33,25.1-2.19,40.9"/>
 				</g>
 			</g>
 		</g>

--- a/kanji/0825a-KaishoVtLst.svg
+++ b/kanji/0825a-KaishoVtLst.svg
@@ -56,16 +56,16 @@ kvg:type CDATA #IMPLIED >
 				<g id="kvg:0825a-KaishoVtLst-g6" kvg:element="廾" kvg:variant="true">
 					<g id="kvg:0825a-KaishoVtLst-g7" kvg:element="丿" kvg:variant="true">
 						<g id="kvg:0825a-KaishoVtLst-g8" kvg:element="十" kvg:part="1">
-							<path id="kvg:0825a-KaishoVtLst-s10" kvg:type="㇑" d="M52.34,46.29c8.98-0.82,18.01-1.27,27.01-1.82c1.04-0.06,3.04-0.12,4-0.18"/>
+							<path id="kvg:0825a-KaishoVtLst-s10" kvg:type="㇐" d="M52.34,46.29c8.98-0.82,18.01-1.27,27.01-1.82c1.04-0.06,3.04-0.12,4-0.18"/>
 						</g>
 					</g>
-					<path id="kvg:0825a-KaishoVtLst-s11" kvg:type="㇑" d="M52.75,57.92c4.87-0.38,29.43-1.84,35.5-2.17"/>
+					<path id="kvg:0825a-KaishoVtLst-s11" kvg:type="㇐" d="M52.75,57.92c4.87-0.38,29.43-1.84,35.5-2.17"/>
 					<g id="kvg:0825a-KaishoVtLst-g9" kvg:element="日" kvg:part="2">
 						<g id="kvg:0825a-KaishoVtLst-g10" kvg:element="十" kvg:part="2">
-							<path id="kvg:0825a-KaishoVtLst-s12" kvg:type="㇐" d="M60.58,14.08c0.63,0.38,2.09,1.17,2.09,3.27c0,17.02,0.91,31.57,1.08,39.07"/>
+							<path id="kvg:0825a-KaishoVtLst-s12" kvg:type="㇑" d="M60.58,14.08c0.63,0.38,2.09,1.17,2.09,3.27c0,17.02,0.91,31.57,1.08,39.07"/>
 						</g>
 					</g>
-					<path id="kvg:0825a-KaishoVtLst-s13" kvg:type="㇐" d="M76.75,12.75c0.59,0.38,1.75,1.5,1.67,3.5c-0.94,22.76-1.43,22.79-2.25,38.59"/>
+					<path id="kvg:0825a-KaishoVtLst-s13" kvg:type="㇑" d="M76.75,12.75c0.59,0.38,1.75,1.5,1.67,3.5c-0.94,22.76-1.43,22.79-2.25,38.59"/>
 				</g>
 			</g>
 		</g>

--- a/kanji/08276-Kaisho.svg
+++ b/kanji/08276-Kaisho.svg
@@ -45,7 +45,7 @@ kvg:type CDATA #IMPLIED >
 			</g>
 			<g id="kvg:08276-Kaisho-g4" kvg:element="廾">
 				<g id="kvg:08276-Kaisho-g5" kvg:element="十" kvg:part="1">
-					<path id="kvg:08276-Kaisho-s3" kvg:type="㇐" d="M26.34,15.58c0.5,0.21,1.17,1.74,1.21,2.17c0.78,9.45,0.64,22.11,0.98,25.99"/>
+					<path id="kvg:08276-Kaisho-s3" kvg:type="㇑" d="M26.34,15.58c0.5,0.21,1.17,1.74,1.21,2.17c0.78,9.45,0.64,22.11,0.98,25.99"/>
 				</g>
 				<g id="kvg:08276-Kaisho-g6" kvg:element="丿" kvg:variant="true">
 					<path id="kvg:08276-Kaisho-s4" kvg:type="㇑" d="M38.82,13.75c0.52,0.22,0.98,1.98,0.94,2.42c-1,13.23-1.72,17.36-2.44,26.54"/>

--- a/kanji/08276-KaishoVtLst.svg
+++ b/kanji/08276-KaishoVtLst.svg
@@ -48,14 +48,14 @@ kvg:type CDATA #IMPLIED >
 					<path id="kvg:08276-KaishoVtLst-s3" kvg:type="㇐" d="M18.15,35.75c8.35-0.75,13.47-1.56,20-2.36c0.83-0.1,1.63-0.2,2.4-0.29"/>
 				</g>
 				<g id="kvg:08276-KaishoVtLst-g6" kvg:element="丿" kvg:variant="true">
-					<path id="kvg:08276-KaishoVtLst-s4" kvg:type="㇑" d="M19.75,44.68c3.66-0.31,21.25-1.98,25.81-2.25"/>
+					<path id="kvg:08276-KaishoVtLst-s4" kvg:type="㇐" d="M19.75,44.68c3.66-0.31,21.25-1.98,25.81-2.25"/>
 				</g>
 				<g id="kvg:08276-KaishoVtLst-g7" kvg:element="十" kvg:part="2">
 					<path id="kvg:08276-KaishoVtLst-s5" kvg:type="㇑" d="M26.34,15.58c0.5,0.21,1.17,1.74,1.21,2.17c0.78,9.45,0.64,22.11,0.98,25.99"/>
 				</g>
 			</g>
 			<g id="kvg:08276-KaishoVtLst-g8" kvg:element="日" kvg:part="2">
-				<path id="kvg:08276-KaishoVtLst-s6" kvg:type="㇐" d="M38.82,13.75c0.52,0.22,0.98,1.98,0.94,2.42c-1,13.23-1.72,17.36-2.44,26.54"/>
+				<path id="kvg:08276-KaishoVtLst-s6" kvg:type="㇑" d="M38.82,13.75c0.52,0.22,0.98,1.98,0.94,2.42c-1,13.23-1.72,17.36-2.44,26.54"/>
 			</g>
 		</g>
 		<g id="kvg:08276-KaishoVtLst-g9" kvg:element="豆" kvg:position="bottom">

--- a/kanji/08c4a-Kaisho.svg
+++ b/kanji/08c4a-Kaisho.svg
@@ -44,7 +44,7 @@ kvg:type CDATA #IMPLIED >
 		</g>
 		<g id="kvg:08c4a-Kaisho-g3" kvg:element="廾">
 			<g id="kvg:08c4a-Kaisho-g4" kvg:element="十" kvg:part="1">
-				<path id="kvg:08c4a-Kaisho-s3" kvg:type="㇐" d="M40.73,11.59c0.82,0.26,1.92,2.16,1.98,2.69C44,26,46.29,41.69,46.86,46.5"/>
+				<path id="kvg:08c4a-Kaisho-s3" kvg:type="㇑" d="M40.73,11.59c0.82,0.26,1.92,2.16,1.98,2.69C44,26,46.29,41.69,46.86,46.5"/>
 			</g>
 			<g id="kvg:08c4a-Kaisho-g5" kvg:element="丿" kvg:variant="true">
 				<path id="kvg:08c4a-Kaisho-s4" kvg:type="㇑" d="M62.92,10.25c0.82,0.26,1.54,1.16,1.48,1.69c-1.57,15.72-2.71,23-3.84,33.91"/>

--- a/kanji/08c4a-KaishoVtLst.svg
+++ b/kanji/08c4a-KaishoVtLst.svg
@@ -47,14 +47,14 @@ kvg:type CDATA #IMPLIED >
 				<path id="kvg:08c4a-KaishoVtLst-s3" kvg:type="㇐" d="M29.18,35.07c11.2,0,22.54-1.4,33.71-2.13c1.4-0.09,4.25-0.18,5.55-0.26"/>
 			</g>
 			<g id="kvg:08c4a-KaishoVtLst-g5" kvg:element="丿" kvg:variant="true">
-				<path id="kvg:08c4a-KaishoVtLst-s4" kvg:type="㇑" d="M31.88,47.7c6.16-0.39,35.83-2.53,43.5-2.86"/>
+				<path id="kvg:08c4a-KaishoVtLst-s4" kvg:type="㇐" d="M31.88,47.7c6.16-0.39,35.83-2.53,43.5-2.86"/>
 			</g>
 			<g id="kvg:08c4a-KaishoVtLst-g6" kvg:element="十" kvg:part="2">
 				<path id="kvg:08c4a-KaishoVtLst-s5" kvg:type="㇑" d="M40.73,11.59c0.82,0.26,1.92,2.16,1.98,2.69C44,26,46.29,41.69,46.86,46.5"/>
 			</g>
 		</g>
 		<g id="kvg:08c4a-KaishoVtLst-g7" kvg:element="日" kvg:part="2">
-			<path id="kvg:08c4a-KaishoVtLst-s6" kvg:type="㇐" d="M62.92,10.25c0.82,0.26,1.54,1.16,1.48,1.69c-1.57,15.72-2.71,23-3.84,33.91"/>
+			<path id="kvg:08c4a-KaishoVtLst-s6" kvg:type="㇑" d="M62.92,10.25c0.82,0.26,1.54,1.16,1.48,1.69c-1.57,15.72-2.71,23-3.84,33.91"/>
 		</g>
 	</g>
 	<g id="kvg:08c4a-KaishoVtLst-g8" kvg:element="豆" kvg:position="bottom" kvg:radical="general">

--- a/kanji/08ec6-Kaisho.svg
+++ b/kanji/08ec6-Kaisho.svg
@@ -54,7 +54,7 @@ kvg:type CDATA #IMPLIED >
 			</g>
 			<g id="kvg:08ec6-Kaisho-g5" kvg:element="廾">
 				<g id="kvg:08ec6-Kaisho-g6" kvg:element="十" kvg:part="1">
-					<path id="kvg:08ec6-Kaisho-s10" kvg:type="㇐" d="M62.63,13.42c0.58,0.23,1.36,1.89,1.4,2.35C64.94,26,64.96,38.5,64.96,43.4"/>
+					<path id="kvg:08ec6-Kaisho-s10" kvg:type="㇑" d="M62.63,13.42c0.58,0.23,1.36,1.89,1.4,2.35C64.94,26,64.96,38.5,64.96,43.4"/>
 				</g>
 				<g id="kvg:08ec6-Kaisho-g7" kvg:element="丿" kvg:variant="true">
 					<path id="kvg:08ec6-Kaisho-s11" kvg:type="㇑" d="M77.3,12.75c0.58,0.23,1.08,2.01,1.05,2.47c-0.85,10.48-0.63,14.75-1.71,27.61"/>

--- a/kanji/08ec6-KaishoVtLst.svg
+++ b/kanji/08ec6-KaishoVtLst.svg
@@ -57,14 +57,14 @@ kvg:type CDATA #IMPLIED >
 					<path id="kvg:08ec6-KaishoVtLst-s10" kvg:type="㇐" d="M53.98,33.42c7.9,0,15.94-1.23,23.8-1.86c0.99-0.08,1.94-0.16,2.86-0.23"/>
 				</g>
 				<g id="kvg:08ec6-KaishoVtLst-g7" kvg:element="丿" kvg:variant="true">
-					<path id="kvg:08ec6-KaishoVtLst-s11" kvg:type="㇑" d="M55.38,43.94c4.35-0.34,26.3-1.21,31.71-1.5"/>
+					<path id="kvg:08ec6-KaishoVtLst-s11" kvg:type="㇐" d="M55.38,43.94c4.35-0.34,26.3-1.21,31.71-1.5"/>
 				</g>
 				<g id="kvg:08ec6-KaishoVtLst-g8" kvg:element="十" kvg:part="2">
 					<path id="kvg:08ec6-KaishoVtLst-s12" kvg:type="㇑" d="M62.63,13.42c0.58,0.23,1.36,1.89,1.4,2.35C64.94,26,64.96,38.5,64.96,43.4"/>
 				</g>
 			</g>
 			<g id="kvg:08ec6-KaishoVtLst-g9" kvg:element="日" kvg:part="2">
-				<path id="kvg:08ec6-KaishoVtLst-s13" kvg:type="㇐" d="M77.3,12.75c0.58,0.23,1.08,2.01,1.05,2.47c-0.85,10.48-0.63,14.75-1.71,27.61"/>
+				<path id="kvg:08ec6-KaishoVtLst-s13" kvg:type="㇑" d="M77.3,12.75c0.58,0.23,1.08,2.01,1.05,2.47c-0.85,10.48-0.63,14.75-1.71,27.61"/>
 			</g>
 		</g>
 		<g id="kvg:08ec6-KaishoVtLst-g10" kvg:element="豆" kvg:position="bottom">

--- a/kanji/0906d-KaishoVtLst.svg
+++ b/kanji/0906d-KaishoVtLst.svg
@@ -48,16 +48,16 @@ kvg:type CDATA #IMPLIED >
 				<g id="kvg:0906d-KaishoVtLst-g5" kvg:element="廾" kvg:variant="true">
 					<g id="kvg:0906d-KaishoVtLst-g6" kvg:element="丿" kvg:variant="true">
 						<g id="kvg:0906d-KaishoVtLst-g7" kvg:element="十" kvg:part="1">
-							<path id="kvg:0906d-KaishoVtLst-s4" kvg:type="㇑" d="M44.59,40.97c9.55-0.72,19.09-1.66,28.64-2.47c1.1-0.09,2.67-0.18,3.68-0.27"/>
+							<path id="kvg:0906d-KaishoVtLst-s4" kvg:type="㇐" d="M44.59,40.97c9.55-0.72,19.09-1.66,28.64-2.47c1.1-0.09,2.67-0.18,3.68-0.27"/>
 						</g>
 					</g>
-					<path id="kvg:0906d-KaishoVtLst-s5" kvg:type="㇑" d="M47.21,50.26c5.1-0.33,29.74-2.54,36.1-2.83"/>
+					<path id="kvg:0906d-KaishoVtLst-s5" kvg:type="㇐" d="M47.21,50.26c5.1-0.33,29.74-2.54,36.1-2.83"/>
 					<g id="kvg:0906d-KaishoVtLst-g8" kvg:element="日" kvg:part="2">
 						<g id="kvg:0906d-KaishoVtLst-g9" kvg:element="十" kvg:part="2">
-							<path id="kvg:0906d-KaishoVtLst-s6" kvg:type="㇐" d="M55.71,12.28c0.66,0.33,1.14,1.46,1.19,2.13c1.02,14.79,1.41,28.27,1.86,34.32"/>
+							<path id="kvg:0906d-KaishoVtLst-s6" kvg:type="㇑" d="M55.71,12.28c0.66,0.33,1.14,1.46,1.19,2.13c1.02,14.79,1.41,28.27,1.86,34.32"/>
 						</g>
 					</g>
-					<path id="kvg:0906d-KaishoVtLst-s7" kvg:type="㇐" d="M71.54,9.75c0.66,0.33,1.23,1.46,1.18,2.13c-1.26,19.81-0.89,22.28-1.8,36.03"/>
+					<path id="kvg:0906d-KaishoVtLst-s7" kvg:type="㇑" d="M71.54,9.75c0.66,0.33,1.23,1.46,1.18,2.13c-1.26,19.81-0.89,22.28-1.8,36.03"/>
 				</g>
 			</g>
 		</g>

--- a/kanji/091b4-Kaisho.svg
+++ b/kanji/091b4-Kaisho.svg
@@ -60,7 +60,7 @@ kvg:type CDATA #IMPLIED >
 			</g>
 			<g id="kvg:091b4-Kaisho-g8" kvg:element="廾">
 				<g id="kvg:091b4-Kaisho-g9" kvg:element="十" kvg:part="1">
-					<path id="kvg:091b4-Kaisho-s10" kvg:type="㇐" d="M63.16,14.33c0.6,0.21,1.42,1.75,1.43,2.18c0.16,7.99,1,21.24,1,25.58"/>
+					<path id="kvg:091b4-Kaisho-s10" kvg:type="㇑" d="M63.16,14.33c0.6,0.21,1.42,1.75,1.43,2.18c0.16,7.99,1,21.24,1,25.58"/>
 				</g>
 				<g id="kvg:091b4-Kaisho-g10" kvg:element="丿" kvg:variant="true">
 					<path id="kvg:091b4-Kaisho-s11" kvg:type="㇑" d="M78.2,12.75c0.6,0.21,1.11,2.44,1.07,2.87c-1.14,12.72-1.46,17.11-2.28,25.94"/>

--- a/kanji/091b4-KaishoVtLst.svg
+++ b/kanji/091b4-KaishoVtLst.svg
@@ -63,14 +63,14 @@ kvg:type CDATA #IMPLIED >
 					<path id="kvg:091b4-KaishoVtLst-s10" kvg:type="㇐" d="M54.3,33.34c6,0,16.61-1.32,22.59-1.76c2.13-0.16,3.85-0.07,6.28,0.04"/>
 				</g>
 				<g id="kvg:091b4-KaishoVtLst-g10" kvg:element="丿" kvg:variant="true">
-					<path id="kvg:091b4-KaishoVtLst-s11" kvg:type="㇑" d="M55.76,43.05c4.46-0.32,26.4-1.54,31.95-1.82"/>
+					<path id="kvg:091b4-KaishoVtLst-s11" kvg:type="㇐" d="M55.76,43.05c4.46-0.32,26.4-1.54,31.95-1.82"/>
 				</g>
 				<g id="kvg:091b4-KaishoVtLst-g11" kvg:element="十" kvg:part="2">
 					<path id="kvg:091b4-KaishoVtLst-s12" kvg:type="㇑" d="M63.16,14.33c0.6,0.21,1.42,1.75,1.43,2.18c0.16,7.99,1,21.24,1,25.58"/>
 				</g>
 			</g>
 			<g id="kvg:091b4-KaishoVtLst-g12" kvg:element="日" kvg:part="2">
-				<path id="kvg:091b4-KaishoVtLst-s13" kvg:type="㇐" d="M78.2,12.75c0.6,0.21,1.11,2.44,1.07,2.87c-1.14,12.72-1.46,17.11-2.28,25.94"/>
+				<path id="kvg:091b4-KaishoVtLst-s13" kvg:type="㇑" d="M78.2,12.75c0.6,0.21,1.11,2.44,1.07,2.87c-1.14,12.72-1.46,17.11-2.28,25.94"/>
 			</g>
 		</g>
 		<g id="kvg:091b4-KaishoVtLst-g13" kvg:element="豆" kvg:position="bottom">

--- a/kanji/09ad4-Kaisho.svg
+++ b/kanji/09ad4-Kaisho.svg
@@ -61,7 +61,7 @@ kvg:type CDATA #IMPLIED >
 			</g>
 			<g id="kvg:09ad4-Kaisho-g7" kvg:element="廾">
 				<g id="kvg:09ad4-Kaisho-g8" kvg:element="十" kvg:part="1">
-					<path id="kvg:09ad4-Kaisho-s13" kvg:type="㇐" d="M65.05,13.81c0.57,0.21,1.33,1.7,1.37,2.12c0.89,9.25,2.48,21.62,2.87,25.41"/>
+					<path id="kvg:09ad4-Kaisho-s13" kvg:type="㇑" d="M65.05,13.81c0.57,0.21,1.33,1.7,1.37,2.12c0.89,9.25,2.48,21.62,2.87,25.41"/>
 				</g>
 				<g id="kvg:09ad4-Kaisho-g9" kvg:element="丿" kvg:variant="true">
 					<path id="kvg:09ad4-Kaisho-s14" kvg:type="㇑" d="M80.02,12c0.73,0.26,0.85,1.67,0.81,2.2c-0.58,8.05-1.83,23.3-1.9,27.13"/>

--- a/kanji/09ad4-KaishoHzFst.svg
+++ b/kanji/09ad4-KaishoHzFst.svg
@@ -61,7 +61,7 @@ kvg:type CDATA #IMPLIED >
 			</g>
 			<g id="kvg:09ad4-KaishoHzFst-g7" kvg:element="廾">
 				<g id="kvg:09ad4-KaishoHzFst-g8" kvg:element="十" kvg:part="1">
-					<path id="kvg:09ad4-KaishoHzFst-s13" kvg:type="㇐" d="M65.05,13.81c0.57,0.21,1.33,1.7,1.37,2.12c0.89,9.25,2.48,21.62,2.87,25.41"/>
+					<path id="kvg:09ad4-KaishoHzFst-s13" kvg:type="㇑" d="M65.05,13.81c0.57,0.21,1.33,1.7,1.37,2.12c0.89,9.25,2.48,21.62,2.87,25.41"/>
 				</g>
 				<g id="kvg:09ad4-KaishoHzFst-g9" kvg:element="丿" kvg:variant="true">
 					<path id="kvg:09ad4-KaishoHzFst-s14" kvg:type="㇑" d="M80.02,12c0.73,0.26,0.85,1.67,0.81,2.2c-0.58,8.05-1.83,23.3-1.9,27.13"/>

--- a/kanji/09af7-Kaisho.svg
+++ b/kanji/09af7-Kaisho.svg
@@ -62,7 +62,7 @@ kvg:type CDATA #IMPLIED >
 		</g>
 		<g id="kvg:09af7-Kaisho-g7" kvg:element="廾">
 			<g id="kvg:09af7-Kaisho-g8" kvg:element="十" kvg:part="1">
-				<path id="kvg:09af7-Kaisho-s13" kvg:type="㇐" d="M43.65,54.53c1.25,0.64,2.73,2.84,2.86,4.13c1.6,15.84,1.24,22.84,2.11,33.28"/>
+				<path id="kvg:09af7-Kaisho-s13" kvg:type="㇑" d="M43.65,54.53c1.25,0.64,2.73,2.84,2.86,4.13c1.6,15.84,1.24,22.84,2.11,33.28"/>
 			</g>
 			<g id="kvg:09af7-Kaisho-g9" kvg:element="丿" kvg:variant="true">
 				<path id="kvg:09af7-Kaisho-s14" kvg:type="㇑" d="M64.29,53.23c1.25,0.63,1.75,2.84,1.63,4.13c-1.16,12.32-1.02,26.54-1.94,33.72"/>

--- a/kanji/09af7-KaishoHzFst.svg
+++ b/kanji/09af7-KaishoHzFst.svg
@@ -62,7 +62,7 @@ kvg:type CDATA #IMPLIED >
 		</g>
 		<g id="kvg:09af7-KaishoHzFst-g7" kvg:element="廾">
 			<g id="kvg:09af7-KaishoHzFst-g8" kvg:element="十" kvg:part="1">
-				<path id="kvg:09af7-KaishoHzFst-s13" kvg:type="㇐" d="M43.65,54.53c1.25,0.64,2.73,2.84,2.86,4.13c1.6,15.84,1.24,22.84,2.11,33.28"/>
+				<path id="kvg:09af7-KaishoHzFst-s13" kvg:type="㇑" d="M43.65,54.53c1.25,0.64,2.73,2.84,2.86,4.13c1.6,15.84,1.24,22.84,2.11,33.28"/>
 			</g>
 			<g id="kvg:09af7-KaishoHzFst-g9" kvg:element="丿" kvg:variant="true">
 				<path id="kvg:09af7-KaishoHzFst-s14" kvg:type="㇑" d="M64.29,53.23c1.25,0.63,1.75,2.84,1.63,4.13c-1.16,12.32-1.02,26.54-1.94,33.72"/>

--- a/kanji/09c67-Kaisho.svg
+++ b/kanji/09c67-Kaisho.svg
@@ -66,7 +66,7 @@ kvg:type CDATA #IMPLIED >
 			</g>
 			<g id="kvg:09c67-Kaisho-g9" kvg:element="廾">
 				<g id="kvg:09c67-Kaisho-g10" kvg:element="十" kvg:part="1">
-					<path id="kvg:09c67-Kaisho-s14" kvg:type="㇐" d="M62.37,13.45c0.58,0.23,1.36,1.94,1.4,2.41c0.91,10.52,2.53,22.1,2.93,26.41"/>
+					<path id="kvg:09c67-Kaisho-s14" kvg:type="㇑" d="M62.37,13.45c0.58,0.23,1.36,1.94,1.4,2.41c0.91,10.52,2.53,22.1,2.93,26.41"/>
 				</g>
 				<g id="kvg:09c67-Kaisho-g11" kvg:element="丿" kvg:variant="true">
 					<path id="kvg:09c67-Kaisho-s15" kvg:type="㇑" d="M78.56,12.25c0.58,0.23,1.11,2.04,1.05,2.52c-0.6,4.98-1.26,14.72-2.22,26.43"/>

--- a/kanji/09c67-KaishoVtLst.svg
+++ b/kanji/09c67-KaishoVtLst.svg
@@ -69,14 +69,14 @@ kvg:type CDATA #IMPLIED >
 					<path id="kvg:09c67-KaishoVtLst-s14" kvg:type="㇐" d="M54.71,32.02c7.9,0,15.96-1.26,23.83-1.92c0.99-0.08,3.95-0.16,4.86-0.24"/>
 				</g>
 				<g id="kvg:09c67-KaishoVtLst-g11" kvg:element="丿" kvg:variant="true">
-					<path id="kvg:09c67-KaishoVtLst-s15" kvg:type="㇑" d="M56.61,43.35c4.36-0.35,25.33-2.27,30.75-2.57"/>
+					<path id="kvg:09c67-KaishoVtLst-s15" kvg:type="㇐" d="M56.61,43.35c4.36-0.35,25.33-2.27,30.75-2.57"/>
 				</g>
 				<g id="kvg:09c67-KaishoVtLst-g12" kvg:element="十" kvg:part="2">
 					<path id="kvg:09c67-KaishoVtLst-s16" kvg:type="㇑" d="M62.37,13.45c0.58,0.23,1.36,1.94,1.4,2.41c0.91,10.52,2.53,22.1,2.93,26.41"/>
 				</g>
 			</g>
 			<g id="kvg:09c67-KaishoVtLst-g13" kvg:element="日" kvg:part="2">
-				<path id="kvg:09c67-KaishoVtLst-s17" kvg:type="㇐" d="M78.56,12.25c0.58,0.23,1.11,2.04,1.05,2.52c-0.6,4.98-1.26,14.72-2.22,26.43"/>
+				<path id="kvg:09c67-KaishoVtLst-s17" kvg:type="㇑" d="M78.56,12.25c0.58,0.23,1.11,2.04,1.05,2.52c-0.6,4.98-1.26,14.72-2.22,26.43"/>
 			</g>
 		</g>
 		<g id="kvg:09c67-KaishoVtLst-g14" kvg:element="豆" kvg:position="bottom">


### PR DESCRIPTION
This fixes a large number of incidences of incorrect stroke type on
kanji which contain a 曲 element. It does not resolve problems with
incorrect group labelling.