### PR TITLE
Remove "position" value for outermost element

### DIFF
--- a/kanji/05e2d-Kaisho.svg
+++ b/kanji/05e2d-Kaisho.svg
@@ -36,7 +36,7 @@ kvg:type CDATA #IMPLIED >
 ]>
 <svg xmlns="http://www.w3.org/2000/svg" width="109" height="109" viewBox="0 0 109 109">
 <g id="kvg:StrokePaths_05e2d-Kaisho" style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;">
-<g id="kvg:05e2d-Kaisho" kvg:element="席" kvg:position="tare">
+<g id="kvg:05e2d-Kaisho" kvg:element="席">
 	<g id="kvg:05e2d-Kaisho-g1" kvg:element="广" kvg:radical="nelson">
 		<path id="kvg:05e2d-Kaisho-s1" kvg:type="㇑a" d="M51.3,9.63c1.97,0.77,6.14,5.77,6.53,7.3"/>
 		<g id="kvg:05e2d-Kaisho-g2" kvg:element="厂">

--- a/kanji/08129-Kaisho.svg
+++ b/kanji/08129-Kaisho.svg
@@ -36,7 +36,7 @@ kvg:type CDATA #IMPLIED >
 ]>
 <svg xmlns="http://www.w3.org/2000/svg" width="109" height="109" viewBox="0 0 109 109">
 <g id="kvg:StrokePaths_08129-Kaisho" style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;">
-<g id="kvg:08129-Kaisho" kvg:element="脩" kvg:position="left">
+<g id="kvg:08129-Kaisho" kvg:element="脩">
 	<g id="kvg:08129-Kaisho-g1" kvg:element="攸" kvg:part="1" kvg:variant="true">
 		<g id="kvg:08129-Kaisho-g2" kvg:element="亻" kvg:variant="true" kvg:original="人" kvg:position="left" kvg:radical="nelson">
 			<path id="kvg:08129-Kaisho-s1" kvg:type="㇒" d="M32,14.75c0.24,2.17-0.07,5.01-0.85,6.87C26.19,33.48,19.89,44.61,8.5,59.04"/>

--- a/kanji/08912-Kaisho.svg
+++ b/kanji/08912-Kaisho.svg
@@ -36,7 +36,7 @@ kvg:type CDATA #IMPLIED >
 ]>
 <svg xmlns="http://www.w3.org/2000/svg" width="109" height="109" viewBox="0 0 109 109">
 <g id="kvg:StrokePaths_08912-Kaisho" style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;">
-<g id="kvg:08912-Kaisho" kvg:element="褒" kvg:position="top">
+<g id="kvg:08912-Kaisho" kvg:element="褒">
 	<g id="kvg:08912-Kaisho-g1" kvg:element="衣" kvg:part="1" kvg:radical="tradit">
 		<g id="kvg:08912-Kaisho-g2" kvg:element="亠" kvg:radical="nelson">
 			<path id="kvg:08912-Kaisho-s1" kvg:type="㇑a" d="M50.16,8c1.74,0.94,4.59,3.75,5.59,6.42"/>

--- a/kanji/09ece-Kaisho.svg
+++ b/kanji/09ece-Kaisho.svg
@@ -36,7 +36,7 @@ kvg:type CDATA #IMPLIED >
 ]>
 <svg xmlns="http://www.w3.org/2000/svg" width="109" height="109" viewBox="0 0 109 109">
 <g id="kvg:StrokePaths_09ece-Kaisho" style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;">
-<g id="kvg:09ece-Kaisho" kvg:element="黎" kvg:position="top">
+<g id="kvg:09ece-Kaisho" kvg:element="黎">
 	<g id="kvg:09ece-Kaisho-g1" kvg:position="left">
 		<g id="kvg:09ece-Kaisho-g2" kvg:element="黍" kvg:part="1" kvg:radical="tradit">
 			<g id="kvg:09ece-Kaisho-g3" kvg:element="禾" kvg:position="top">

--- a/kanji/09ece.svg
+++ b/kanji/09ece.svg
@@ -36,7 +36,7 @@ kvg:type CDATA #IMPLIED >
 ]>
 <svg xmlns="http://www.w3.org/2000/svg" width="109" height="109" viewBox="0 0 109 109">
 <g id="kvg:StrokePaths_09ece" style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;">
-<g id="kvg:09ece" kvg:element="黎" kvg:position="top">
+<g id="kvg:09ece" kvg:element="黎">
 	<g id="kvg:09ece-g1" kvg:position="left">
 		<g id="kvg:09ece-g2" kvg:element="黍" kvg:part="1" kvg:radical="tradit">
 			<g id="kvg:09ece-g3" kvg:element="禾" kvg:position="top">

--- a/kanji/09ed2-KaishoVtLst.svg
+++ b/kanji/09ed2-KaishoVtLst.svg
@@ -36,7 +36,7 @@ kvg:type CDATA #IMPLIED >
 ]>
 <svg xmlns="http://www.w3.org/2000/svg" width="109" height="109" viewBox="0 0 109 109">
 <g id="kvg:StrokePaths_09ed2-KaishoVtLst" style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;">
-<g id="kvg:09ed2-KaishoVtLst" kvg:element="黒" kvg:variant="true" kvg:original="黑" kvg:position="top" kvg:radical="general">
+<g id="kvg:09ed2-KaishoVtLst" kvg:element="黒" kvg:variant="true" kvg:original="黑" kvg:radical="general">
 	<g id="kvg:09ed2-KaishoVtLst-g1" kvg:element="里" kvg:variant="true">
 		<path id="kvg:09ed2-KaishoVtLst-s1" kvg:type="㇑" d="M28.86,18.41c0.41,0.45,1.02,1.74,1.15,2.33c1.49,7.13,3.09,17.77,4.24,26.51"/>
 		<path id="kvg:09ed2-KaishoVtLst-s2" kvg:type="㇕" d="M31.12,19.98c14.88-1.61,36.4-3.64,46.2-4.54c4.01,0.28,5.73,1.68,5.15,4.17c-0.68,5.04-3.39,17.11-5.89,24.23"/>


### PR DESCRIPTION
The position value indicates where the element lies with respect to
other elements, but these elements have "position" set where the
element is the outermost one which represents the entire set of
strokes, in other words there is no other element to be relative to,
so the position seems to be useless.