### PR TITLE
Added python3 support, added lookup utility

### DIFF
--- a/kvg-lookup.py
+++ b/kvg-lookup.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python
+#  -*- coding: utf-8 -*-
+#
+#  Copyright (C) 2023 Sebastian Grygiel
+#  Copyright (C) 2011-2013 Alexandre Courbot
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import sys, os, re, datetime
+from kanjivg import Stroke, StrokeGr
+from utils import listSvgFiles, readXmlFile, canonicalId, PYTHON_VERSION_MAJOR
+
+if PYTHON_VERSION_MAJOR > 2:
+	def unicode(s):
+		return s
+	def unichr(c):
+		return chr(c)
+
+helpString = """Usage: %s <find-svg|find-xml> <element1> [...elementN]
+
+Recognized commands:
+  find-svg      Find and view summary of an SVG file for the given 
+                element in ./kanji/ directory.
+  find-xml      Find and view summary of a <kanji> entry for
+                the given element from ./kanjivg.xml file.
+
+Parameters:
+  element 	    May either be the singular character, e.g. 並 or its
+                unicode code-point e.g. 4e26.
+
+Examples:
+  %s find-svg 並      Will list SVG files describing given character.
+  %s find-xml 4e26    Will list <kanji> entry for the same character.
+""" % (sys.argv[0], sys.argv[0], sys.argv[0])
+
+# Output helper
+
+lossInWeirdEncoding = False
+def writeOutput(data, output):
+	if PYTHON_VERSION_MAJOR >= 3:
+		output.write(data)
+		return
+	
+	global lossInWeirdEncoding
+	if output.encoding == None:
+		encoding = 'utf8'
+	else:
+		encoding = output.encoding
+
+	encoded = data.encode(encoding, errors="replace")
+	if encoding != 'utf8' and encoding != 'utf-8':
+		if encoded.decode(encoding) != data:
+			lossInWeirdEncoding = encoding
+	
+	output.write(encoded)
+
+# Summary generators
+
+def strokeGroupSummary(gr, indent = 0):
+	if not isinstance(gr, StrokeGr):
+		raise Exception("Invalid structure")
+	
+	ret = unicode(" " * indent * 4)
+	# ret += gr.element if gr.element is not None and len(gr.element) > 0 else "・"
+	ret += "- group"
+	if gr.element is not None and len(gr.element) > 0:
+		ret += " %s" % (gr.element,)
+	if gr.position:
+		ret += " (%s)" % (gr.position,)
+
+	childStrokes = [s.stype for s in gr.childs if isinstance(s, Stroke) and s.stype]
+	if len(childStrokes):
+		ret += "\n%s- strokes: %s" % (" " * (indent+1) * 4, ' '.join(childStrokes))
+
+	ret += "\n"
+
+	for g in gr.childs:
+		if isinstance(g, StrokeGr):
+			ret += strokeGroupSummary(g, indent + 1)
+
+	return ret
+
+def characterSummary(c):
+	ret = "Character summary: %s (%s)" % (c.code, c.strokes.element)
+	if c.variant:
+		ret += " - variant: %s" % (c.variant)
+	ret += "\n"
+	ret += strokeGroupSummary(c.strokes)
+	return ret
+
+# Commands
+
+def commandFindSvg(arg):
+	id = canonicalId(arg)
+	kanji = [(f.path, f.read()) for f in listSvgFiles("./kanji/") if f.id == id]
+	print("Found %d files matching ID %s" % (len(kanji), id))
+	for i, (path, c) in enumerate(kanji):
+		print("\nFile %s (%d/%d):" % (path, i+1, len(kanji)))
+		writeOutput(characterSummary(c) + "\n", sys.stdout)
+
+def commandFindXml(arg):
+	id = canonicalId(arg)
+	files = readXmlFile('./kanjivg.xml')
+	if id in files:
+		writeOutput(characterSummary(files[id]) + "\n", sys.stdout)
+	else:
+		writeOutput(unicode("Character %s (%s) not found.\n") % (id, unichr(int(id, 16))), sys.stdout)
+
+# Main wrapper
+
+actions = {
+	"find-svg": (commandFindSvg, 2),
+	"find-xml": (commandFindXml, 2),
+}
+
+if __name__ == "__main__":
+	if len(sys.argv) < 2 or sys.argv[1] not in actions.keys() or \
+		len(sys.argv) <= actions[sys.argv[1]][1]:
+		print(helpString)
+		sys.exit(0)
+
+	action = actions[sys.argv[1]][0]
+	args = sys.argv[2:]
+
+	if len(args) == 0:
+		action()
+	else:
+		for f in args:
+			action(f)
+	
+	if lossInWeirdEncoding:
+		notice = """\nNotice: SOME CHARACTERS IN THE OUTPUT HAVE BEEN REPLACED WITH QUESTION MARKS.
+        The text output has been encoded using your encoding of the standard
+        output (%s). Try redirecting output to file if you can't get it to
+        work in terminal. e.g.: kvg-lookup.py find-svg 4e26 > output.txt\n""" % (lossInWeirdEncoding,)
+		writeOutput(notice, sys.stderr)

--- a/kvg-lookup.py
+++ b/kvg-lookup.py
@@ -36,7 +36,7 @@ Recognized commands:
                 the given element from ./kanjivg.xml file.
 
 Parameters:
-  element 	    May either be the singular character, e.g. 並 or its
+  element       May either be the singular character, e.g. 並 or its
                 unicode code-point e.g. 4e26.
 
 Examples:

--- a/kvg.py
+++ b/kvg.py
@@ -16,8 +16,9 @@
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import os, os.path, sys, codecs, re, datetime
+import sys, os, re, datetime
 from kanjivg import licenseString
+from utils import open
 
 pathre = re.compile(r'<path .*d="([^"]*)".*/>')
 
@@ -28,9 +29,9 @@ Recognized commands:
   release                         create single release file""" % (sys.argv[0],)
 
 def createPathsSVG(f):
-	s = codecs.open(f, "r", "utf-8").read()
+	s = open(f, "r", encoding="utf-8").read()
 	paths = pathre.findall(s)
-	out = codecs.open(f[:-4] + "-paths.svg", "w", "utf-8")
+	out = open(f[:-4] + "-paths.svg", "w", encoding="utf-8")
 	out.write("""<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.0//EN" "http://www.w3.org/TR/2001/REC-SVG-20010904/DTD/svg10.dtd" []>
 <svg xmlns="http://www.w3.org/2000/svg" width="109" height="109" viewBox="0 0 109 109" style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;">\n""")
 	i = 1
@@ -44,20 +45,21 @@ def mergePathsSVG(f):
 	if not os.path.exists(pFile):
 		print("%s does not exist!" % (pFile,))
 		return
-	s = codecs.open(pFile, "r", "utf-8").read()
+	s = open(pFile, "r", encoding="utf-8").read()
 	paths = pathre.findall(s)
-	s = codecs.open(f, "r", "utf-8").read()
+	s = open(f, "r", encoding="utf-8").read()
 	pos = 0
 	while True:
 		match = pathre.search(s[pos:])
 		if match and len(paths) == 0 or not match and len(paths) > 0:
 			print("Paths count mismatch for %s" % (f,))
 			return
-		if not match and len(paths) == 0: break
+		if not match and len(paths) == 0:
+			break
 		s = s[:pos + match.start(1)] + paths[0] + s[pos + match.end(1):]
 		pos += match.start(1) + len(paths[0])
 		del paths[0]
-	codecs.open(f, "w", "utf-8").write(s)
+	open(f, "w", encoding="utf-8").write(s)
 
 def release():
 	datadir = "kanji"
@@ -69,7 +71,7 @@ def release():
 	del allfiles
 	files.sort()
 	
-	out = open("kanjivg.xml", "w")
+	out = open("kanjivg.xml", "w", encoding='utf8')
 	out.write('<?xml version="1.0" encoding="UTF-8"?>\n')
 	out.write("<!--\n")
 	out.write(licenseString)
@@ -77,7 +79,8 @@ def release():
 	out.write("\n-->\n")
 	out.write("<kanjivg xmlns:kvg='http://kanjivg.tagaini.net'>\n")
 	for f in files:
-		data = open(os.path.join(datadir, f)).read()
+		data = open(os.path.join(datadir, f), encoding='utf8').read()
+		data = data.replace("\r\n", "\n")
 		data = data[data.find("<svg "):]
 		data = data[data.find(idMatchString) + len(idMatchString):]
 		kidend = data.find("\"")
@@ -102,7 +105,8 @@ if __name__ == "__main__":
 	action = actions[sys.argv[1]][0]
 	files = sys.argv[2:]
 
-	if len(files) == 0: action()
+	if len(files) == 0:
+		action()
 	else:
 		for f in files:
 			if not os.path.exists(f):

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,75 @@
+import sys, os
+
+PYTHON_VERSION_MAJOR = sys.version_info[0]
+
+if PYTHON_VERSION_MAJOR < 3:
+    # In python 2, io.open does not support encoding parameter
+    from codecs import open
+else:
+    from io import open
+    # In python 3, strings are used so unicode() is a pass-through
+    def unicode(s):
+        return s
+
+def canonicalId(id):
+    if isinstance(id, str):
+        idLen = len(id)
+        if idLen == 1:
+            id = ord(id)
+        elif idLen >= 2 and idLen <= 5:
+            id = int(id, 16)
+        else:
+            raise ValueError("Character id must be a 1-character string with the character itself, or 2-5 hex digit unicode codepoint.")
+    if not isinstance(id, int):
+        raise ValueError("canonicalId: id must be int or str")
+    if id > 0xf and id <= 0xfffff:
+        return "%05x" % (id)
+    raise ValueError("Character id out of range")
+
+class SvgFileInfo:
+    def __init__(self, file, dir):
+        self.path = os.path.join(dir, file)
+        if file[-4:].lower() != ".svg":
+            raise Exception("File should have .svg exension. (%s)" % (str(self.path)))
+        parts = (file[:-4]).split('-')
+        if len(parts) == 2:
+            self.variant = parts[1]
+        elif len(parts) != 1:
+            raise Exception("File should have at most 2 parts separated by a dash. (%s)" % (str(file)))
+        self.id = parts[0]
+        if self.id != canonicalId(self.id):
+            raise Exception("File name not in canonical format (%s)" % (str(self.path)))
+
+    def __repr__(self):
+         return repr(vars(self))
+
+    def read(self, SVGHandler=None):    
+        if SVGHandler is None:
+            from kanjivg import SVGHandler 
+        handler = SVGHandler()
+        parseXmlFile(self.path, handler)
+        parsed = list(handler.kanjis.values())
+        if len(parsed) != 1:
+            raise Exception("File does not contain 1 kanji entry. (%s)" % (self.path))
+        return parsed[0]
+
+def parseXmlFile(path, handler):
+    from xml.sax import parse
+    parse(path, handler)
+
+def listSvgFiles(dir):
+    return [
+        SvgFileInfo(f, dir)
+        for f in os.listdir(dir)
+    ]
+
+def readXmlFile(path, KanjisHandler=None):
+    if KanjisHandler is None:
+        from kanjivg import KanjisHandler
+    handler = KanjisHandler()
+    parseXmlFile(path, handler)
+    parsed = list(handler.kanjis.values())
+    if len(parsed) == 0:
+        raise Exception("File does not contain any kanji entries. (%s)" % (path))
+    return handler.kanjis
+


### PR DESCRIPTION
### Python 3 support
I have updated `kvg.py` and `kanjivg.py` files to work with both Python 2 and Python 3 (tested 2.7 and 3.9).

### XML Handler Fixes
I have updated `KanjisHandler` and `SVGHandler` XML-parsing classes in `kanjivg.py` to work on the current SVG/XML structure. I may have been confused by them, but I could not get them to work, so I rewrote some functionality.

 - In case of `SVGHandler` the changes were limited to accounting for the parent StrokePaths group and ignoring it.
 - In case of `KanjisHandler` the changes involved re-writing how it processes each kanji in turn, as I could not figure out how it was meant to be used.

### New command-line utility

I added a utility for displaying a summary of a character based on SVG or XML files. It is useful for checking that the SVGHandler and KanjisHandler classes work correctly at first glance. It is also an example of how to use XML parsing.



```
$ python .\kvg-lookup.py            
Usage: .\kvg-lookup.py <find-svg|find-xml> <element1> [...elementN]

Recognized commands:
  find-svg      Find and view summary of an SVG file for the given
                element in ./kanji/ directory.
  find-xml      Find and view summary of a <kanji> entry for
                the given element from ./kanjivg.xml file.

Parameters:
  element           May either be the singular character, e.g. 並 or its
                unicode code-point e.g. 4e26.

Examples:
  .\kvg-lookup.py find-svg 並      Will list SVG files describing given character.
  .\kvg-lookup.py find-xml 4e26    Will list <kanji> entry for the same character.
```

```
$ python .\kvg-lookup.py find-svg 香  
Found 2 files matching ID 09999

File ./kanji/09999-Kaisho.svg (1/2):
Character summary: 09999 (香) - variant: Kaisho
- group 香
    - group 禾 (top)
        - group 丿 (top)
            - strokes: ㇒
        - group 木 (bottom)
            - strokes: ㇐ ㇑ ㇒ ㇏
    - group 日 (bottom)
        - strokes: ㇑ ㇕a ㇐a ㇐a


File ./kanji/09999.svg (2/2):
Character summary: 09999 (香)
- group 香
    - group 禾 (top)
        - group 丿 (top)
            - strokes: ㇒
        - group 木 (bottom)
            - strokes: ㇐ ㇑ ㇒ ㇏
    - group 日 (bottom)
        - strokes: ㇑ ㇕a ㇐a ㇐a
```
