### PR TITLE
fixed 欝 (06b1d-KaishoLeFst) - stroke numbers and actual strokes do not align

### DIFF
--- a/kanji/06b1d-KaishoLeFst.svg
+++ b/kanji/06b1d-KaishoLeFst.svg
@@ -38,11 +38,11 @@ kvg:type CDATA #IMPLIED >
 <g id="kvg:StrokePaths_06b1d-KaishoLeFst" style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;">
 <g id="kvg:06b1d-KaishoLeFst" kvg:element="欝">
 	<g id="kvg:06b1d-KaishoLeFst-g1" kvg:element="棥" kvg:position="top">
-		<g id="kvg:06b1d-KaishoLeFst-g2" kvg:element="木" kvg:radical="general">
-			<path id="kvg:06b1d-KaishoLeFst-s1" kvg:type="㇐" d="M64.5,18.35c0.66,0.21,1.4,0.28,2.16,0.21c3.84-0.35,17.5-1.57,23.31-1.98c0.75-0.05,1.22,0.04,1.97,0.19"/>
-			<path id="kvg:06b1d-KaishoLeFst-s2" kvg:type="㇑" d="M76.08,9.25c0.59,0.23,1.06,1.04,1.06,1.53c0,4.93,0,23.04-0.12,25.97"/>
-			<path id="kvg:06b1d-KaishoLeFst-s3" kvg:type="㇒" d="M77,18.03c-2.3,5.21-8.46,13.17-13.25,16.12"/>
-			<path id="kvg:06b1d-KaishoLeFst-s4" kvg:type="㇏" d="M76.78,17.94c2.29,2.03,13.06,12.24,15.55,14.24c0.84,0.68,1.57,0.97,2.41,1.16"/>
+		<g id="kvg:06b1d-KaishoLeFst-g6" kvg:element="木">
+			<path id="kvg:06b1d-KaishoLeFst-s1" kvg:type="㇒" d="M30.94,20.28c-5.98,8.84-9.31,12.57-18.58,20.31"/>
+			<path id="kvg:06b1d-KaishoLeFst-s2" kvg:type="㇏" d="M32.72,23.9c2.3,1.12,5.47,4.96,7.41,7.14"/>
+			<path id="kvg:06b1d-KaishoLeFst-s3" kvg:type="㇒" d="M59.77,9.64c0.04,0.35,0.08,0.91-0.08,1.42c-0.97,3-6.53,9.58-14.13,13.61"/>
+			<path id="kvg:06b1d-KaishoLeFst-s4" kvg:type="㇏" d="M46.42,12.48c5.11,1,11.9,6.03,13.89,9.52"/>
 		</g>
 		<g id="kvg:06b1d-KaishoLeFst-g3" kvg:element="爻">
 			<g id="kvg:06b1d-KaishoLeFst-g4" kvg:element="乂">
@@ -54,11 +54,11 @@ kvg:type CDATA #IMPLIED >
 				<path id="kvg:06b1d-KaishoLeFst-s8" kvg:type="㇑" d="M46.97,28.78c4.12,1.71,9.03,5.5,11.33,8.14"/>
 			</g>
 		</g>
-		<g id="kvg:06b1d-KaishoLeFst-g6" kvg:element="木">
-			<path id="kvg:06b1d-KaishoLeFst-s9" kvg:type="㇒" d="M30.94,20.28c-5.98,8.84-9.31,12.57-18.58,20.31"/>
-			<path id="kvg:06b1d-KaishoLeFst-s10" kvg:type="㇏" d="M32.72,23.9c2.3,1.12,5.47,4.96,7.41,7.14"/>
-			<path id="kvg:06b1d-KaishoLeFst-s11" kvg:type="㇒" d="M59.77,9.64c0.04,0.35,0.08,0.91-0.08,1.42c-0.97,3-6.53,9.58-14.13,13.61"/>
-			<path id="kvg:06b1d-KaishoLeFst-s12" kvg:type="㇏" d="M46.42,12.48c5.11,1,11.9,6.03,13.89,9.52"/>
+		<g id="kvg:06b1d-KaishoLeFst-g2" kvg:element="木" kvg:radical="general">
+			<path id="kvg:06b1d-KaishoLeFst-s9" kvg:type="㇐" d="M64.5,18.35c0.66,0.21,1.4,0.28,2.16,0.21c3.84-0.35,17.5-1.57,23.31-1.98c0.75-0.05,1.22,0.04,1.97,0.19"/>
+			<path id="kvg:06b1d-KaishoLeFst-s10" kvg:type="㇑" d="M76.08,9.25c0.59,0.23,1.06,1.04,1.06,1.53c0,4.93,0,23.04-0.12,25.97"/>
+			<path id="kvg:06b1d-KaishoLeFst-s11" kvg:type="㇒" d="M77,18.03c-2.3,5.21-8.46,13.17-13.25,16.12"/>
+			<path id="kvg:06b1d-KaishoLeFst-s12" kvg:type="㇏" d="M76.78,17.94c2.29,2.03,13.06,12.24,15.55,14.24c0.84,0.68,1.57,0.97,2.41,1.16"/>
 		</g>
 	</g>
 	<g id="kvg:06b1d-KaishoLeFst-g7" kvg:position="bottom">

--- a/kanji/06b1d-KaishoLeFst.svg
+++ b/kanji/06b1d-KaishoLeFst.svg
@@ -39,15 +39,15 @@ kvg:type CDATA #IMPLIED >
 <g id="kvg:06b1d-KaishoLeFst" kvg:element="欝">
 	<g id="kvg:06b1d-KaishoLeFst-g1" kvg:element="棥" kvg:position="top">
 		<g id="kvg:06b1d-KaishoLeFst-g6" kvg:element="木">
-			<path id="kvg:06b1d-KaishoLeFst-s1" kvg:type="㇒" d="M30.94,20.28c-5.98,8.84-9.31,12.57-18.58,20.31"/>
-			<path id="kvg:06b1d-KaishoLeFst-s2" kvg:type="㇏" d="M32.72,23.9c2.3,1.12,5.47,4.96,7.41,7.14"/>
-			<path id="kvg:06b1d-KaishoLeFst-s3" kvg:type="㇒" d="M59.77,9.64c0.04,0.35,0.08,0.91-0.08,1.42c-0.97,3-6.53,9.58-14.13,13.61"/>
-			<path id="kvg:06b1d-KaishoLeFst-s4" kvg:type="㇏" d="M46.42,12.48c5.11,1,11.9,6.03,13.89,9.52"/>
+			<path id="kvg:06b1d-KaishoLeFst-s1" kvg:type="㇒" d="M13.28,20.72c0.35,0.24,2.38,0.35,3.31,0.31c7.42-0.28,14.67-1.28,23.95-1.91c0.93-0.06,1.15-0.24,1.73,0"/>			
+			<path id="kvg:06b1d-KaishoLeFst-s2" kvg:type="㇏" d="M29.79,10c0.53,0.27,1.17,1.15,1.17,2.55c0,0.55-0.07,23.34-0.17,26.7"/>
+			<path id="kvg:06b1d-KaishoLeFst-s3" kvg:type="㇒" d="M30.94,20.28c-5.98,8.84-9.31,12.57-18.58,20.31"/>
+			<path id="kvg:06b1d-KaishoLeFst-s4" kvg:type="㇏" d="M32.72,23.9c2.3,1.12,5.47,4.96,7.41,7.14"/>
 		</g>
 		<g id="kvg:06b1d-KaishoLeFst-g3" kvg:element="爻">
 			<g id="kvg:06b1d-KaishoLeFst-g4" kvg:element="乂">
-				<path id="kvg:06b1d-KaishoLeFst-s5" kvg:type="㇒" d="M13.28,20.72c0.35,0.24,2.38,0.35,3.31,0.31c7.42-0.28,14.67-1.28,23.95-1.91c0.93-0.06,1.15-0.24,1.73,0"/>
-				<path id="kvg:06b1d-KaishoLeFst-s6" kvg:type="㇏" d="M29.79,10c0.53,0.27,1.17,1.15,1.17,2.55c0,0.55-0.07,23.34-0.17,26.7"/>
+				<path id="kvg:06b1d-KaishoLeFst-s5" kvg:type="㇒" d="M59.77,9.64c0.04,0.35,0.08,0.91-0.08,1.42c-0.97,3-6.53,9.58-14.13,13.61"/>
+				<path id="kvg:06b1d-KaishoLeFst-s6" kvg:type="㇏" d="M46.42,12.48c5.11,1,11.9,6.03,13.89,9.52"/>
 			</g>
 			<g id="kvg:06b1d-KaishoLeFst-g5" kvg:element="乂" kvg:position="bottom">
 				<path id="kvg:06b1d-KaishoLeFst-s7" kvg:type="㇐" d="M57.33,26.47c0.04,0.31,0.08,0.79-0.08,1.23c-0.94,2.59-6.33,8.29-13.7,11.77"/>


### PR DESCRIPTION
Fixes #421 

The stroke numbers and the actual svg paths do not match for this entry.

<img width="291" alt="image" src="https://github.com/KanjiVG/kanjivg/assets/51273483/c51dd84e-b981-4712-bcac-5c677b328a81">

The 木 marked in green in the image above has the s1-s4 description.