### PR TITLE
Reorganize to group together 奞 in 奮, which lines up better with etymology

### DIFF
--- a/kanji/0596e.svg
+++ b/kanji/0596e.svg
@@ -37,12 +37,12 @@ kvg:type CDATA #IMPLIED >
 <svg xmlns="http://www.w3.org/2000/svg" width="109" height="109" viewBox="0 0 109 109">
 <g id="kvg:StrokePaths_0596e" style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;">
 <g id="kvg:0596e" kvg:element="奮">
-	<g id="kvg:0596e-g1" kvg:element="大" kvg:position="top" kvg:radical="general">
-		<path id="kvg:0596e-s1" kvg:type="㇐" d="M21.62,23.86c2.83,0.68,5.66,0.58,8.5,0.24c17.5-2.1,37.03-3.27,50.63-4.06c2.79-0.16,6.11,0.08,8.49,0.46"/>
-		<path id="kvg:0596e-s2" kvg:type="㇒" d="M53.03,9.5c0.22,1.5-0.38,2.87-1.04,3.85C43,26.75,31.75,38.75,11.5,49.5"/>
-		<path id="kvg:0596e-s3" kvg:type="㇏" d="M59,22c7.38,5.22,23.36,17.53,30.73,21.02c2.51,1.19,3.38,1.37,4.52,1.48"/>
-	</g>
-	<g id="kvg:0596e-g2" kvg:position="bottom">
+	<g id="kvg:0596e-g1" kvg:element="奞" kvg:position="top">
+		<g id="kvg:0596e-g2" kvg:element="大" kvg:position="top" kvg:radical="general">
+			<path id="kvg:0596e-s1" kvg:type="㇐" d="M21.62,23.86c2.83,0.68,5.66,0.58,8.5,0.24c17.5-2.1,37.03-3.27,50.63-4.06c2.79-0.16,6.11,0.08,8.49,0.46"/>
+			<path id="kvg:0596e-s2" kvg:type="㇒" d="M53.03,9.5c0.22,1.5-0.38,2.87-1.04,3.85C43,26.75,31.75,38.75,11.5,49.5"/>
+			<path id="kvg:0596e-s3" kvg:type="㇏" d="M59,22c7.38,5.22,23.36,17.53,30.73,21.02c2.51,1.19,3.38,1.37,4.52,1.48"/>
+		</g>
 		<g id="kvg:0596e-g3" kvg:element="隹" kvg:position="top">
 			<g id="kvg:0596e-g4" kvg:element="亻" kvg:variant="true" kvg:original="人">
 				<path id="kvg:0596e-s4" kvg:type="㇒" d="M41.42,34.25c0.17,1.14-0.05,2.39-0.58,3.37c-3.42,6.25-7.21,11.88-15.58,19.14"/>
@@ -55,7 +55,9 @@ kvg:type CDATA #IMPLIED >
 			<path id="kvg:0596e-s10" kvg:type="㇐b" d="M37.87,61.74c5.63-0.3,21.81-0.92,29.89-1.36c1.97-0.11,3.4-0.19,3.98-0.23"/>
 			<path id="kvg:0596e-s11" kvg:type="㇐b" d="M38.06,70.31c5.73-0.44,25.68-2.11,35.2-2.56c2.16-0.1,3.75-0.13,4.49-0.04"/>
 		</g>
-		<g id="kvg:0596e-g5" kvg:element="田" kvg:position="bottom">
+  </g>
+	<g id="kvg:0596e-g5" kvg:position="bottom">
+		<g id="kvg:0596e-g6" kvg:element="田" kvg:position="bottom">
 			<path id="kvg:0596e-s12" kvg:type="㇑" d="M30.07,78.93c0.35,0.34,0.36,0.58,0.55,1.01c1.24,2.81,2.4,10.26,3.29,16.5c0.23,1.61,0.44,3.15,0.64,4.5"/>
 			<path id="kvg:0596e-s13" kvg:type="㇕a" d="M31.21,79.93c14.66-1.18,36.98-3.42,46.21-3.63c2.08-0.05,3.58,1.08,2.93,3.99c-0.62,2.79-1.9,8.54-3.89,14.19c-0.51,1.44-1.06,2.85-1.67,4.15"/>
 			<path id="kvg:0596e-s14" kvg:type="㇑a" d="M53.69,80.27c0.53,0.33,1.17,2.11,1.16,2.61c-0.05,3.94-0.11,9.62-0.23,13.55"/>


### PR DESCRIPTION
According to wiktionary, the top two components are a single etymological unit:

Ideogrammic compound (會意／会意): 奞 (“bird”) + 田 (“field”) – bird spreading its wings to fly.

https://en.wiktionary.org/wiki/%E5%A5%AE