### PR TITLE
Fix 09dd7 - add missing and adjust stroke numbers

### DIFF
--- a/kanji/087ec-Kaisho.svg
+++ b/kanji/087ec-Kaisho.svg
@@ -87,8 +87,8 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 7.50 47.50)">1</text>
 	<text transform="matrix(1 0 0 1 16.50 38.50)">2</text>
 	<text transform="matrix(1 0 0 1 19.50 58.85)">3</text>
-	<text transform="matrix(1 0 0 1 15.50 18.50)">4</text>
-	<text transform="matrix(1 0 0 1 4.50 87.50)">5</text>
+	<text transform="matrix(1 0 0 1 18.00 18.50)">4</text>
+	<text transform="matrix(1 0 0 1 5.50 86.50)">5</text>
 	<text transform="matrix(1 0 0 1 39.50 66.50)">6</text>
 	<text transform="matrix(1 0 0 1 43.50 22.50)">7</text>
 	<text transform="matrix(1 0 0 1 52.00 13.10)">8</text>
@@ -99,8 +99,8 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 44.50 46.50)">13</text>
 	<text transform="matrix(1 0 0 1 58.25 34.50)">14</text>
 	<text transform="matrix(1 0 0 1 57.50 46.80)">15</text>
-	<text transform="matrix(1 0 0 1 57.50 66.80)">16</text>
-	<text transform="matrix(1 0 0 1 47.50 70.80)">17</text>
-	<text transform="matrix(1 0 0 1 57.50 86.80)">18</text>
+	<text transform="matrix(1 0 0 1 57.50 58.75)">16</text>
+	<text transform="matrix(1 0 0 1 47.50 72.50)">17</text>
+	<text transform="matrix(1 0 0 1 61.75 70.00)">18</text>
 </g>
 </svg>

--- a/kanji/087ec.svg
+++ b/kanji/087ec.svg
@@ -85,8 +85,8 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 7.50 47.50)">1</text>
 	<text transform="matrix(1 0 0 1 16.50 38.50)">2</text>
 	<text transform="matrix(1 0 0 1 19.50 58.85)">3</text>
-	<text transform="matrix(1 0 0 1 15.50 18.50)">4</text>
-	<text transform="matrix(1 0 0 1 4.50 87.50)">5</text>
+	<text transform="matrix(1 0 0 1 18.00 18.50)">4</text>
+	<text transform="matrix(1 0 0 1 5.50 86.50)">5</text>
 	<text transform="matrix(1 0 0 1 39.50 66.50)">6</text>
 	<text transform="matrix(1 0 0 1 43.50 22.50)">7</text>
 	<text transform="matrix(1 0 0 1 52.00 13.10)">8</text>
@@ -97,5 +97,8 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 44.50 46.50)">13</text>
 	<text transform="matrix(1 0 0 1 58.25 34.50)">14</text>
 	<text transform="matrix(1 0 0 1 57.50 46.80)">15</text>
+	<text transform="matrix(1 0 0 1 57.50 58.75)">16</text>
+	<text transform="matrix(1 0 0 1 47.50 72.50)">17</text>
+	<text transform="matrix(1 0 0 1 61.75 70.00)">18</text>
 </g>
 </svg>


### PR DESCRIPTION
- Adjusted stroke order positions in 087ec-Kaisho which were misaligned, and copied to 087ec where some were missing

Glad to report that after this and #452 there will be no missing stroke numbers in the repository for base forms (I haven't checked variants yet, and have only checked if they exist and not if their position is correct).