### PR TITLE
Handle Dated Versioning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,9 @@ classifiers = [
 ]
 
 [tool.setuptools_scm]
+version_scheme = "no-guess-dev"
 local_scheme = "no-local-version"
+tag_regex = "^(?:r)?(\\d{8}-?\\d?)$"
 
 [project.urls]
 Homepage = "https://github.com/KanjiVG/kanjivg"


### PR DESCRIPTION
Looks like when #467 was merged, I did not account for the `r20240808` format of the version numbers for releases. This fixes that so it will build. Here's hoping it works correctly.