### PR TITLE
Added missing stroke numbers in Kaisho kanji

### DIFF
--- a/kanji/05dd2-Kaisho.svg
+++ b/kanji/05dd2-Kaisho.svg
@@ -94,5 +94,7 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 68.50 53.50)">18</text>
 	<text transform="matrix(1 0 0 1 77.50 49.50)">19</text>
 	<text transform="matrix(1 0 0 1 42.50 70.50)">20</text>
+	<text transform="matrix(1 0 0 1 15.50 76.50)">21</text>
+	<text transform="matrix(1 0 0 1 73.50 75.50)">22</text>
 </g>
 </svg>

--- a/kanji/05f4e-Kaisho.svg
+++ b/kanji/05f4e-Kaisho.svg
@@ -94,5 +94,7 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 62.50 52.50)">18</text>
 	<text transform="matrix(1 0 0 1 77.50 43.50)">19</text>
 	<text transform="matrix(1 0 0 1 31.50 57.20)">20</text>
+	<text transform="matrix(1 0 0 1 37.25 67.13)">21</text>
+	<text transform="matrix(1 0 0 1 21.50 73.13)">22</text>
 </g>
 </svg>

--- a/kanji/0622f-VtFstLeRiTenFst.svg
+++ b/kanji/0622f-VtFstLeRiTenFst.svg
@@ -64,8 +64,9 @@ kvg:type CDATA #IMPLIED >
 		<g id="kvg:0622f-VtFstLeRiTenFst-g8" kvg:element="弋" kvg:part="1">
 			<path id="kvg:0622f-VtFstLeRiTenFst-s12" kvg:type="㇐" d="M58.5,46.52c0.65,0.23,1.83,0.28,2.48,0.23c11.77-0.93,21.02-5.43,26.51-6.58c1.05-0.22,1.72,0.11,2.26,0.23"/>
 			<path id="kvg:0622f-VtFstLeRiTenFst-s13" kvg:type="㇂" d="M65.25,10.57c1,1.25,2.05,2.41,2.33,6.46C69.9,50.94,79.5,80.82,93.66,96.2c4.48,4.87,5.09,1.87,4.32-9.04"/>
-			<g id="kvg:0622f-VtFstLeRiTenFst-g9" kvg:element="丶"></g>
-			<path id="kvg:0622f-VtFstLeRiTenFst-s14" kvg:type="丶" d="M78.5,19.32c3.1,2.35,7.55,7.72,9,11.75"/>
+			<g id="kvg:0622f-VtFstLeRiTenFst-g9" kvg:element="丶">
+				<path id="kvg:0622f-VtFstLeRiTenFst-s14" kvg:type="丶" d="M78.5,19.32c3.1,2.35,7.55,7.72,9,11.75"/>
+			</g>
 		</g>
 		<g id="kvg:0622f-VtFstLeRiTenFst-g10" kvg:element="丿" kvg:radical="nelson">
 			<path id="kvg:0622f-VtFstLeRiTenFst-s15" kvg:type="㇒" d="M88.73,50.96c0.07,0.71,0.15,1.84-0.14,2.86c-1.75,6.02-11.82,19.91-25.59,28"/>

--- a/kanji/06ade-Kaisho.svg
+++ b/kanji/06ade-Kaisho.svg
@@ -91,5 +91,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 63.25 65.50)">16</text>
 	<text transform="matrix(1 0 0 1 64.50 79.50)">17</text>
 	<text transform="matrix(1 0 0 1 84.50 51.50)">18</text>
+	<text transform="matrix(1 0 0 1 83.50 73.28)">19</text>
 </g>
 </svg>

--- a/kanji/06b12-Kaisho.svg
+++ b/kanji/06b12-Kaisho.svg
@@ -96,5 +96,7 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 77.00 47.25)">19</text>
 	<text transform="matrix(1 0 0 1 6.50 73.50)">20</text>
 	<text transform="matrix(1 0 0 1 44.50 63.50)">21</text>
+	<text transform="matrix(1 0 0 1 30.50 81.50)">22</text>
+	<text transform="matrix(1 0 0 1 72.50 79.50)">23</text>
 </g>
 </svg>

--- a/kanji/07063-Kaisho.svg
+++ b/kanji/07063-Kaisho.svg
@@ -104,5 +104,7 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 76.50 43.50)">21</text>
 	<text transform="matrix(1 0 0 1 83.50 41.50)">22</text>
 	<text transform="matrix(1 0 0 1 44.50 58.88)">23</text>
+	<text transform="matrix(1 0 0 1 42.50 68.63)">24</text>
+	<text transform="matrix(1 0 0 1 33.50 76.38)">25</text>
 </g>
 </svg>

--- a/kanji/07cfa-Kaisho.svg
+++ b/kanji/07cfa-Kaisho.svg
@@ -57,5 +57,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 6.50 85.50)">4</text>
 	<text transform="matrix(1 0 0 1 20.50 80.50)">5</text>
 	<text transform="matrix(1 0 0 1 33.50 75.50)">6</text>
+	<text transform="matrix(1 0 0 1 53.50 13.50)">7</text>
 </g>
 </svg>

--- a/kanji/07cfe-Kaisho.svg
+++ b/kanji/07cfe-Kaisho.svg
@@ -63,5 +63,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 31.50 73.50)">6</text>
 	<text transform="matrix(1 0 0 1 52.50 22.50)">7</text>
 	<text transform="matrix(1 0 0 1 51.50 65.50)">8</text>
+	<text transform="matrix(1 0 0 1 72.50 12.50)">9</text>
 </g>
 </svg>

--- a/kanji/07d00-Kaisho.svg
+++ b/kanji/07d00-Kaisho.svg
@@ -61,5 +61,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 31.50 74.50)">6</text>
 	<text transform="matrix(1 0 0 1 55.99 24.50)">7</text>
 	<text transform="matrix(1 0 0 1 58.99 47.50)">8</text>
+	<text transform="matrix(1 0 0 1 60.50 59.53)">9</text>
 </g>
 </svg>

--- a/kanji/07d02-Kaisho.svg
+++ b/kanji/07d02-Kaisho.svg
@@ -61,5 +61,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 30.50 73.50)">6</text>
 	<text transform="matrix(1 0 0 1 47.50 34.50)">7</text>
 	<text transform="matrix(1 0 0 1 70.25 14.50)">8</text>
+	<text transform="matrix(1 0 0 1 52.50 49.50)">9</text>
 </g>
 </svg>

--- a/kanji/07d04-Kaisho.svg
+++ b/kanji/07d04-Kaisho.svg
@@ -67,5 +67,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 31.50 74.50)">6</text>
 	<text transform="matrix(1 0 0 1 56.50 14.50)">7</text>
 	<text transform="matrix(1 0 0 1 62.50 34.50)">8</text>
+	<text transform="matrix(1 0 0 1 55.50 54.50)">9</text>
 </g>
 </svg>

--- a/kanji/07d05-Kaisho.svg
+++ b/kanji/07d05-Kaisho.svg
@@ -61,5 +61,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 30.50 70.50)">6</text>
 	<text transform="matrix(1 0 0 1 51.50 33.50)">7</text>
 	<text transform="matrix(1 0 0 1 62.25 46.63)">8</text>
+	<text transform="matrix(1 0 0 1 52.50 80.50)">9</text>
 </g>
 </svg>

--- a/kanji/07d0b-Kaisho.svg
+++ b/kanji/07d0b-Kaisho.svg
@@ -67,5 +67,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 59.00 14.88)">7</text>
 	<text transform="matrix(1 0 0 1 47.25 32.25)">8</text>
 	<text transform="matrix(1 0 0 1 73.25 43.38)">9</text>
+	<text transform="matrix(1 0 0 1 48.25 47.25)">10</text>
 </g>
 </svg>

--- a/kanji/07d0d-Kaisho.svg
+++ b/kanji/07d0d-Kaisho.svg
@@ -67,5 +67,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 43.50 40.63)">7</text>
 	<text transform="matrix(1 0 0 1 53.25 29.50)">8</text>
 	<text transform="matrix(1 0 0 1 63.50 15.13)">9</text>
+	<text transform="matrix(1 0 0 1 75.75 46.63)">10</text>
 </g>
 </svg>

--- a/kanji/07d10-Kaisho.svg
+++ b/kanji/07d10-Kaisho.svg
@@ -65,5 +65,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 49.50 22.50)">7</text>
 	<text transform="matrix(1 0 0 1 58.50 36.10)">8</text>
 	<text transform="matrix(1 0 0 1 49.50 52.50)">9</text>
+	<text transform="matrix(1 0 0 1 46.50 87.50)">10</text>
 </g>
 </svg>

--- a/kanji/07d14-Kaisho.svg
+++ b/kanji/07d14-Kaisho.svg
@@ -71,5 +71,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 78.50 22.50)">7</text>
 	<text transform="matrix(1 0 0 1 44.50 48.50)">8</text>
 	<text transform="matrix(1 0 0 1 81.50 40.50)">9</text>
+	<text transform="matrix(1 0 0 1 56.50 14.50)">10</text>
 </g>
 </svg>

--- a/kanji/07d15-Kaisho.svg
+++ b/kanji/07d15-Kaisho.svg
@@ -67,5 +67,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 55.44 42.25)">7</text>
 	<text transform="matrix(1 0 0 1 44.50 13.50)">8</text>
 	<text transform="matrix(1 0 0 1 77.94 39.28)">9</text>
+	<text transform="matrix(1 0 0 1 61.44 14.95)">10</text>
 </g>
 </svg>

--- a/kanji/07d17-Kaisho.svg
+++ b/kanji/07d17-Kaisho.svg
@@ -67,5 +67,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 64.25 13.43)">7</text>
 	<text transform="matrix(1 0 0 1 53.25 35.25)">8</text>
 	<text transform="matrix(1 0 0 1 82.25 31.25)">9</text>
+	<text transform="matrix(1 0 0 1 76.25 47.20)">10</text>
 </g>
 </svg>

--- a/kanji/07d18-Kaisho.svg
+++ b/kanji/07d18-Kaisho.svg
@@ -65,5 +65,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 45.25 35.25)">7</text>
 	<text transform="matrix(1 0 0 1 61.25 16.25)">8</text>
 	<text transform="matrix(1 0 0 1 73.25 47.03)">9</text>
+	<text transform="matrix(1 0 0 1 78.25 68.25)">10</text>
 </g>
 </svg>

--- a/kanji/07d19-Kaisho.svg
+++ b/kanji/07d19-Kaisho.svg
@@ -63,5 +63,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 81.75 12.13)">7</text>
 	<text transform="matrix(1 0 0 1 42.75 40.63)">8</text>
 	<text transform="matrix(1 0 0 1 57.75 46.63)">9</text>
+	<text transform="matrix(1 0 0 1 73.50 32.50)">10</text>
 </g>
 </svg>

--- a/kanji/07d1a-Kaisho.svg
+++ b/kanji/07d1a-Kaisho.svg
@@ -65,5 +65,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 25.50 73.50)">6</text>
 	<text transform="matrix(1 0 0 1 47.25 37.63)">7</text>
 	<text transform="matrix(1 0 0 1 53.25 22.63)">8</text>
+	<text transform="matrix(1 0 0 1 60.75 54.13)">9</text>
 </g>
 </svg>

--- a/kanji/07d1c-Kaisho.svg
+++ b/kanji/07d1c-Kaisho.svg
@@ -67,5 +67,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 50.50 17.50)">7</text>
 	<text transform="matrix(1 0 0 1 43.50 43.50)">8</text>
 	<text transform="matrix(1 0 0 1 58.50 55.50)">9</text>
+	<text transform="matrix(1 0 0 1 71.50 64.50)">10</text>
 </g>
 </svg>

--- a/kanji/07d21-Kaisho.svg
+++ b/kanji/07d21-Kaisho.svg
@@ -67,5 +67,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 64.50 13.63)">7</text>
 	<text transform="matrix(1 0 0 1 49.50 31.50)">8</text>
 	<text transform="matrix(1 0 0 1 76.50 47.50)">9</text>
+	<text transform="matrix(1 0 0 1 60.50 43.50)">10</text>
 </g>
 </svg>

--- a/kanji/07d2c-Kaisho.svg
+++ b/kanji/07d2c-Kaisho.svg
@@ -71,5 +71,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 54.00 43.10)">8</text>
 	<text transform="matrix(1 0 0 1 58.25 16.25)">9</text>
 	<text transform="matrix(1 0 0 1 56.99 62.25)">10</text>
+	<text transform="matrix(1 0 0 1 57.25 86.13)">11</text>
 </g>
 </svg>

--- a/kanji/07d30-Kaisho.svg
+++ b/kanji/07d30-Kaisho.svg
@@ -65,5 +65,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 55.50 34.63)">8</text>
 	<text transform="matrix(1 0 0 1 65.50 46.50)">9</text>
 	<text transform="matrix(1 0 0 1 57.50 56.50)">10</text>
+	<text transform="matrix(1 0 0 1 58.50 78.50)">11</text>
 </g>
 </svg>

--- a/kanji/07d32-Kaisho.svg
+++ b/kanji/07d32-Kaisho.svg
@@ -71,5 +71,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 60.50 15.50)">8</text>
 	<text transform="matrix(1 0 0 1 74.50 15.50)">9</text>
 	<text transform="matrix(1 0 0 1 70.25 65.70)">10</text>
+	<text transform="matrix(1 0 0 1 43.50 18.50)">11</text>
 </g>
 </svg>

--- a/kanji/07d33-Kaisho.svg
+++ b/kanji/07d33-Kaisho.svg
@@ -69,5 +69,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 55.50 32.50)">8</text>
 	<text transform="matrix(1 0 0 1 59.25 47.50)">9</text>
 	<text transform="matrix(1 0 0 1 59.25 63.50)">10</text>
+	<text transform="matrix(1 0 0 1 60.50 10.50)">11</text>
 </g>
 </svg>

--- a/kanji/07d35-Kaisho.svg
+++ b/kanji/07d35-Kaisho.svg
@@ -73,5 +73,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 45.50 22.50)">8</text>
 	<text transform="matrix(1 0 0 1 53.50 25.50)">9</text>
 	<text transform="matrix(1 0 0 1 49.25 46.50)">10</text>
+	<text transform="matrix(1 0 0 1 61.50 59.50)">11</text>
 </g>
 </svg>

--- a/kanji/07d39-Kaisho.svg
+++ b/kanji/07d39-Kaisho.svg
@@ -69,5 +69,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 60.50 33.50)">8</text>
 	<text transform="matrix(1 0 0 1 48.75 71.98)">9</text>
 	<text transform="matrix(1 0 0 1 56.25 61.63)">10</text>
+	<text transform="matrix(1 0 0 1 61.50 87.05)">11</text>
 </g>
 </svg>

--- a/kanji/07d3a-Kaisho.svg
+++ b/kanji/07d3a-Kaisho.svg
@@ -71,5 +71,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 49.50 20.50)">8</text>
 	<text transform="matrix(1 0 0 1 74.50 15.50)">9</text>
 	<text transform="matrix(1 0 0 1 61.50 59.50)">10</text>
+	<text transform="matrix(1 0 0 1 62.50 87.50)">11</text>
 </g>
 </svg>

--- a/kanji/07d3f-Kaisho.svg
+++ b/kanji/07d3f-Kaisho.svg
@@ -69,5 +69,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 79.50 28.50)">8</text>
 	<text transform="matrix(1 0 0 1 47.50 76.50)">9</text>
 	<text transform="matrix(1 0 0 1 54.50 62.50)">10</text>
+	<text transform="matrix(1 0 0 1 60.50 90.50)">11</text>
 </g>
 </svg>

--- a/kanji/07d42-Kaisho.svg
+++ b/kanji/07d42-Kaisho.svg
@@ -69,5 +69,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 66.50 17.50)">8</text>
 	<text transform="matrix(1 0 0 1 60.75 32.50)">9</text>
 	<text transform="matrix(1 0 0 1 50.50 64.50)">10</text>
+	<text transform="matrix(1 0 0 1 48.50 80.50)">11</text>
 </g>
 </svg>

--- a/kanji/07d43-Kaisho.svg
+++ b/kanji/07d43-Kaisho.svg
@@ -69,5 +69,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 43.25 27.25)">8</text>
 	<text transform="matrix(1 0 0 1 57.25 38.25)">9</text>
 	<text transform="matrix(1 0 0 1 71.25 41.25)">10</text>
+	<text transform="matrix(1 0 0 1 78.25 68.25)">11</text>
 </g>
 </svg>

--- a/kanji/07d44-Kaisho.svg
+++ b/kanji/07d44-Kaisho.svg
@@ -69,5 +69,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 57.50 20.50)">8</text>
 	<text transform="matrix(1 0 0 1 59.50 42.13)">9</text>
 	<text transform="matrix(1 0 0 1 59.10 60.13)">10</text>
+	<text transform="matrix(1 0 0 1 46.50 87.50)">11</text>
 </g>
 </svg>

--- a/kanji/07d45-Kaisho.svg
+++ b/kanji/07d45-Kaisho.svg
@@ -69,5 +69,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 54.50 15.50)">8</text>
 	<text transform="matrix(1 0 0 1 55.50 47.03)">9</text>
 	<text transform="matrix(1 0 0 1 61.50 36.50)">10</text>
+	<text transform="matrix(1 0 0 1 66.50 63.50)">11</text>
 </g>
 </svg>

--- a/kanji/07d46-Kaisho.svg
+++ b/kanji/07d46-Kaisho.svg
@@ -71,5 +71,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 77.50 18.50)">8</text>
 	<text transform="matrix(1 0 0 1 55.50 42.50)">9</text>
 	<text transform="matrix(1 0 0 1 46.50 62.50)">10</text>
+	<text transform="matrix(1 0 0 1 58.50 10.50)">11</text>
 </g>
 </svg>

--- a/kanji/07d4b-Kaisho.svg
+++ b/kanji/07d4b-Kaisho.svg
@@ -71,5 +71,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 49.50 25.50)">8</text>
 	<text transform="matrix(1 0 0 1 42.50 36.50)">9</text>
 	<text transform="matrix(1 0 0 1 62.25 43.50)">10</text>
+	<text transform="matrix(1 0 0 1 79.50 65.50)">11</text>
 </g>
 </svg>

--- a/kanji/07d4c-Kaisho.svg
+++ b/kanji/07d4c-Kaisho.svg
@@ -69,5 +69,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 59.25 30.13)">8</text>
 	<text transform="matrix(1 0 0 1 48.50 70.50)">9</text>
 	<text transform="matrix(1 0 0 1 56.50 61.50)">10</text>
+	<text transform="matrix(1 0 0 1 39.58 89.10)">11</text>
 </g>
 </svg>

--- a/kanji/07d50-Kaisho.svg
+++ b/kanji/07d50-Kaisho.svg
@@ -71,5 +71,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 53.50 52.03)">9</text>
 	<text transform="matrix(1 0 0 1 45.94 74.50)">10</text>
 	<text transform="matrix(1 0 0 1 56.50 67.50)">11</text>
+	<text transform="matrix(1 0 0 1 62.50 87.80)">12</text>
 </g>
 </svg>

--- a/kanji/07d56-Kaisho.svg
+++ b/kanji/07d56-Kaisho.svg
@@ -77,5 +77,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 81.50 17.50)">9</text>
 	<text transform="matrix(1 0 0 1 43.50 45.50)">10</text>
 	<text transform="matrix(1 0 0 1 50.50 58.38)">11</text>
+	<text transform="matrix(1 0 0 1 63.50 59.50)">12</text>
 </g>
 </svg>

--- a/kanji/07d5e-Kaisho.svg
+++ b/kanji/07d5e-Kaisho.svg
@@ -71,5 +71,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 51.75 43.48)">9</text>
 	<text transform="matrix(1 0 0 1 66.50 39.13)">10</text>
 	<text transform="matrix(1 0 0 1 67.50 51.05)">11</text>
+	<text transform="matrix(1 0 0 1 60.50 58.50)">12</text>
 </g>
 </svg>

--- a/kanji/07d61-Kaisho.svg
+++ b/kanji/07d61-Kaisho.svg
@@ -71,5 +71,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 62.25 33.25)">9</text>
 	<text transform="matrix(1 0 0 1 47.25 78.25)">10</text>
 	<text transform="matrix(1 0 0 1 57.50 68.25)">11</text>
+	<text transform="matrix(1 0 0 1 61.25 89.25)">12</text>
 </g>
 </svg>

--- a/kanji/07d62-Kaisho.svg
+++ b/kanji/07d62-Kaisho.svg
@@ -73,5 +73,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 46.25 52.28)">9</text>
 	<text transform="matrix(1 0 0 1 54.25 44.25)">10</text>
 	<text transform="matrix(1 0 0 1 56.25 57.25)">11</text>
+	<text transform="matrix(1 0 0 1 57.25 71.17)">12</text>
 </g>
 </svg>

--- a/kanji/07d63-Kaisho.svg
+++ b/kanji/07d63-Kaisho.svg
@@ -79,5 +79,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 47.25 31.50)">9</text>
 	<text transform="matrix(1 0 0 1 46.25 54.45)">10</text>
 	<text transform="matrix(1 0 0 1 52.25 44.38)">11</text>
+	<text transform="matrix(1 0 0 1 70.50 42.50)">12</text>
 </g>
 </svg>

--- a/kanji/07d66-Kaisho.svg
+++ b/kanji/07d66-Kaisho.svg
@@ -75,5 +75,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 57.50 49.50)">9</text>
 	<text transform="matrix(1 0 0 1 42.50 75.50)">10</text>
 	<text transform="matrix(1 0 0 1 52.50 64.50)">11</text>
+	<text transform="matrix(1 0 0 1 57.50 89.30)">12</text>
 </g>
 </svg>

--- a/kanji/07d68-Kaisho.svg
+++ b/kanji/07d68-Kaisho.svg
@@ -83,5 +83,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 45.50 63.50)">9</text>
 	<text transform="matrix(1 0 0 1 56.50 13.50)">10</text>
 	<text transform="matrix(1 0 0 1 78.50 47.50)">11</text>
+	<text transform="matrix(1 0 0 1 75.50 14.50)">12</text>
 </g>
 </svg>

--- a/kanji/07d71-Kaisho.svg
+++ b/kanji/07d71-Kaisho.svg
@@ -85,5 +85,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 55.50 37.50)">9</text>
 	<text transform="matrix(1 0 0 1 73.50 36.50)">10</text>
 	<text transform="matrix(1 0 0 1 51.50 61.50)">11</text>
+	<text transform="matrix(1 0 0 1 76.50 60.50)">12</text>
 </g>
 </svg>

--- a/kanji/07d72-Kaisho.svg
+++ b/kanji/07d72-Kaisho.svg
@@ -67,5 +67,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 84.50 44.50)">9</text>
 	<text transform="matrix(1 0 0 1 64.50 69.50)">10</text>
 	<text transform="matrix(1 0 0 1 55.50 73.38)">11</text>
+	<text transform="matrix(1 0 0 1 79.50 69.30)">12</text>
 </g>
 </svg>

--- a/kanji/07d73-Kaisho.svg
+++ b/kanji/07d73-Kaisho.svg
@@ -71,5 +71,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 64.50 26.50)">9</text>
 	<text transform="matrix(1 0 0 1 54.50 58.50)">10</text>
 	<text transform="matrix(1 0 0 1 45.50 69.50)">11</text>
+	<text transform="matrix(1 0 0 1 64.50 51.50)">12</text>
 </g>
 </svg>

--- a/kanji/07d75-Kaisho.svg
+++ b/kanji/07d75-Kaisho.svg
@@ -75,5 +75,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 57.75 49.63)">9</text>
 	<text transform="matrix(1 0 0 1 48.75 64.63)">10</text>
 	<text transform="matrix(1 0 0 1 51.75 78.13)">11</text>
+	<text transform="matrix(1 0 0 1 80.25 76.63)">12</text>
 </g>
 </svg>

--- a/kanji/07d76-Kaisho.svg
+++ b/kanji/07d76-Kaisho.svg
@@ -73,5 +73,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 55.50 43.50)">9</text>
 	<text transform="matrix(1 0 0 1 60.50 52.40)">10</text>
 	<text transform="matrix(1 0 0 1 56.50 60.50)">11</text>
+	<text transform="matrix(1 0 0 1 44.50 51.50)">12</text>
 </g>
 </svg>

--- a/kanji/07d89-Kaisho.svg
+++ b/kanji/07d89-Kaisho.svg
@@ -79,5 +79,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 45.50 44.50)">10</text>
 	<text transform="matrix(1 0 0 1 82.25 40.38)">11</text>
 	<text transform="matrix(1 0 0 1 52.50 67.55)">12</text>
+	<text transform="matrix(1 0 0 1 54.25 54.98)">13</text>
 </g>
 </svg>

--- a/kanji/07d8f-Kaisho.svg
+++ b/kanji/07d8f-Kaisho.svg
@@ -73,5 +73,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 72.50 26.50)">10</text>
 	<text transform="matrix(1 0 0 1 56.75 46.50)">11</text>
 	<text transform="matrix(1 0 0 1 78.50 47.80)">12</text>
+	<text transform="matrix(1 0 0 1 43.50 59.50)">13</text>
 </g>
 </svg>

--- a/kanji/07d93-Kaisho.svg
+++ b/kanji/07d93-Kaisho.svg
@@ -75,5 +75,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 75.50 29.50)">10</text>
 	<text transform="matrix(1 0 0 1 45.50 66.50)">11</text>
 	<text transform="matrix(1 0 0 1 59.50 78.50)">12</text>
+	<text transform="matrix(1 0 0 1 42.50 89.50)">13</text>
 </g>
 </svg>

--- a/kanji/07d99-Kaisho.svg
+++ b/kanji/07d99-Kaisho.svg
@@ -71,5 +71,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 61.50 14.50)">10</text>
 	<text transform="matrix(1 0 0 1 59.50 58.50)">11</text>
 	<text transform="matrix(1 0 0 1 80.50 57.50)">12</text>
+	<text transform="matrix(1 0 0 1 43.50 17.50)">13</text>
 </g>
 </svg>

--- a/kanji/07d9a-Kaisho.svg
+++ b/kanji/07d9a-Kaisho.svg
@@ -79,5 +79,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 43.50 49.50)">10</text>
 	<text transform="matrix(1 0 0 1 63.75 48.13)">11</text>
 	<text transform="matrix(1 0 0 1 50.50 64.50)">12</text>
+	<text transform="matrix(1 0 0 1 76.72 63.69)">13</text>
 </g>
 </svg>

--- a/kanji/07d9b-Kaisho.svg
+++ b/kanji/07d9b-Kaisho.svg
@@ -77,5 +77,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 44.50 67.50)">10</text>
 	<text transform="matrix(1 0 0 1 53.50 81.50)">11</text>
 	<text transform="matrix(1 0 0 1 58.50 64.50)">12</text>
+	<text transform="matrix(1 0 0 1 80.50 73.50)">13</text>
 </g>
 </svg>

--- a/kanji/07d9c-Kaisho.svg
+++ b/kanji/07d9c-Kaisho.svg
@@ -79,5 +79,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 43.25 54.25)">11</text>
 	<text transform="matrix(1 0 0 1 59.50 65.05)">12</text>
 	<text transform="matrix(1 0 0 1 44.50 67.98)">13</text>
+	<text transform="matrix(1 0 0 1 79.25 64.25)">14</text>
 </g>
 </svg>

--- a/kanji/07d9f-Kaisho.svg
+++ b/kanji/07d9f-Kaisho.svg
@@ -73,5 +73,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 41.25 38.95)">10</text>
 	<text transform="matrix(1 0 0 1 53.50 59.63)">11</text>
 	<text transform="matrix(1 0 0 1 60.25 54.25)">12</text>
+	<text transform="matrix(1 0 0 1 77.00 70.48)">13</text>
 </g>
 </svg>

--- a/kanji/07da2-Kaisho.svg
+++ b/kanji/07da2-Kaisho.svg
@@ -79,5 +79,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 61.25 26.63)">11</text>
 	<text transform="matrix(1 0 0 1 53.25 73.25)">12</text>
 	<text transform="matrix(1 0 0 1 61.25 59.48)">13</text>
+	<text transform="matrix(1 0 0 1 65.25 75.25)">14</text>
 </g>
 </svg>

--- a/kanji/07da3-Kaisho.svg
+++ b/kanji/07da3-Kaisho.svg
@@ -83,5 +83,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 57.50 10.50)">11</text>
 	<text transform="matrix(1 0 0 1 78.50 41.50)">12</text>
 	<text transform="matrix(1 0 0 1 57.00 58.48)">13</text>
+	<text transform="matrix(1 0 0 1 46.50 71.50)">14</text>
 </g>
 </svg>

--- a/kanji/07dab-Kaisho.svg
+++ b/kanji/07dab-Kaisho.svg
@@ -91,5 +91,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 46.25 65.25)">11</text>
 	<text transform="matrix(1 0 0 1 52.25 57.25)">12</text>
 	<text transform="matrix(1 0 0 1 74.25 73.25)">13</text>
+	<text transform="matrix(1 0 0 1 67.25 58.25)">14</text>
 </g>
 </svg>

--- a/kanji/07dac-Kaisho.svg
+++ b/kanji/07dac-Kaisho.svg
@@ -79,5 +79,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 40.50 46.50)">11</text>
 	<text transform="matrix(1 0 0 1 56.50 42.30)">12</text>
 	<text transform="matrix(1 0 0 1 51.50 56.50)">13</text>
+	<text transform="matrix(1 0 0 1 45.50 73.50)">14</text>
 </g>
 </svg>

--- a/kanji/07db0-Kaisho.svg
+++ b/kanji/07db0-Kaisho.svg
@@ -77,5 +77,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 56.25 36.25)">11</text>
 	<text transform="matrix(1 0 0 1 58.25 53.25)">12</text>
 	<text transform="matrix(1 0 0 1 58.25 68.25)">13</text>
+	<text transform="matrix(1 0 0 1 58.25 88.25)">14</text>
 </g>
 </svg>

--- a/kanji/07db1-Kaisho.svg
+++ b/kanji/07db1-Kaisho.svg
@@ -75,5 +75,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 56.50 43.63)">11</text>
 	<text transform="matrix(1 0 0 1 63.50 53.50)">12</text>
 	<text transform="matrix(1 0 0 1 54.50 53.50)">13</text>
+	<text transform="matrix(1 0 0 1 74.50 51.13)">14</text>
 </g>
 </svg>

--- a/kanji/07db4-Kaisho.svg
+++ b/kanji/07db4-Kaisho.svg
@@ -83,5 +83,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 39.50 56.50)">11</text>
 	<text transform="matrix(1 0 0 1 44.50 67.50)">12</text>
 	<text transform="matrix(1 0 0 1 68.50 52.50)">13</text>
+	<text transform="matrix(1 0 0 1 71.50 65.50)">14</text>
 </g>
 </svg>

--- a/kanji/07db5-Kaisho.svg
+++ b/kanji/07db5-Kaisho.svg
@@ -75,5 +75,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 44.50 54.50)">11</text>
 	<text transform="matrix(1 0 0 1 55.75 45.50)">12</text>
 	<text transform="matrix(1 0 0 1 53.50 66.50)">13</text>
+	<text transform="matrix(1 0 0 1 75.50 65.50)">14</text>
 </g>
 </svg>

--- a/kanji/07db8-Kaisho.svg
+++ b/kanji/07db8-Kaisho.svg
@@ -89,5 +89,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 50.25 55.25)">11</text>
 	<text transform="matrix(1 0 0 1 50.25 72.05)">12</text>
 	<text transform="matrix(1 0 0 1 63.25 66.25)">13</text>
+	<text transform="matrix(1 0 0 1 76.50 66.25)">14</text>
 </g>
 </svg>

--- a/kanji/07dba-Kaisho.svg
+++ b/kanji/07dba-Kaisho.svg
@@ -85,5 +85,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 43.25 67.25)">11</text>
 	<text transform="matrix(1 0 0 1 52.50 56.25)">12</text>
 	<text transform="matrix(1 0 0 1 56.25 73.25)">13</text>
+	<text transform="matrix(1 0 0 1 74.25 55.25)">14</text>
 </g>
 </svg>

--- a/kanji/07dbb-Kaisho.svg
+++ b/kanji/07dbb-Kaisho.svg
@@ -81,5 +81,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 58.50 56.50)">11</text>
 	<text transform="matrix(1 0 0 1 70.50 61.50)">12</text>
 	<text transform="matrix(1 0 0 1 45.75 57.23)">13</text>
+	<text transform="matrix(1 0 0 1 55.50 76.50)">14</text>
 </g>
 </svg>

--- a/kanji/07dbd-Kaisho.svg
+++ b/kanji/07dbd-Kaisho.svg
@@ -79,5 +79,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 54.25 44.25)">11</text>
 	<text transform="matrix(1 0 0 1 55.25 55.25)">12</text>
 	<text transform="matrix(1 0 0 1 58.25 66.25)">13</text>
+	<text transform="matrix(1 0 0 1 57 66.25)">14</text>
 </g>
 </svg>

--- a/kanji/07dbd-KaishoHzFst.svg
+++ b/kanji/07dbd-KaishoHzFst.svg
@@ -79,5 +79,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 54.25 44.25)">11</text>
 	<text transform="matrix(1 0 0 1 55.25 55.25)">12</text>
 	<text transform="matrix(1 0 0 1 58.25 66.25)">13</text>
+	<text transform="matrix(1 0 0 1 57 66.25)">14</text>
 </g>
 </svg>

--- a/kanji/07dbe-Kaisho.svg
+++ b/kanji/07dbe-Kaisho.svg
@@ -83,5 +83,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 66.75 47.63)">11</text>
 	<text transform="matrix(1 0 0 1 52.25 62.25)">12</text>
 	<text transform="matrix(1 0 0 1 65.25 60.25)">13</text>
+	<text transform="matrix(1 0 0 1 59.75 73.25)">14</text>
 </g>
 </svg>

--- a/kanji/07dbf-Kaisho.svg
+++ b/kanji/07dbf-Kaisho.svg
@@ -79,5 +79,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 59.50 45.50)">11</text>
 	<text transform="matrix(1 0 0 1 45.50 70.50)">12</text>
 	<text transform="matrix(1 0 0 1 54.50 60.50)">13</text>
+	<text transform="matrix(1 0 0 1 61.50 56.50)">14</text>
 </g>
 </svg>

--- a/kanji/07dc7-Kaisho.svg
+++ b/kanji/07dc7-Kaisho.svg
@@ -75,5 +75,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 48.50 58.50)">11</text>
 	<text transform="matrix(1 0 0 1 74.50 69.50)">12</text>
 	<text transform="matrix(1 0 0 1 55.50 75.23)">13</text>
+	<text transform="matrix(1 0 0 1 56.50 91.50)">14</text>
 </g>
 </svg>

--- a/kanji/07dcb-Kaisho.svg
+++ b/kanji/07dcb-Kaisho.svg
@@ -75,5 +75,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 68.25 10.25)">11</text>
 	<text transform="matrix(1 0 0 1 81.45 26.25)">12</text>
 	<text transform="matrix(1 0 0 1 81.50 44.17)">13</text>
+	<text transform="matrix(1 0 0 1 81.33 64.25)">14</text>
 </g>
 </svg>

--- a/kanji/07dcb-KaishoMdFst.svg
+++ b/kanji/07dcb-KaishoMdFst.svg
@@ -71,5 +71,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 45.50 65.25)">11</text>
 	<text transform="matrix(1 0 0 1 81.45 26.25)">12</text>
 	<text transform="matrix(1 0 0 1 81.50 44.17)">13</text>
+	<text transform="matrix(1 0 0 1 81.33 64.25)">14</text>
 </g>
 </svg>

--- a/kanji/07dcf-Kaisho.svg
+++ b/kanji/07dcf-Kaisho.svg
@@ -79,5 +79,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 45.50 72.50)">11</text>
 	<text transform="matrix(1 0 0 1 48.50 63.50)">12</text>
 	<text transform="matrix(1 0 0 1 61.50 63.13)">13</text>
+	<text transform="matrix(1 0 0 1 79.50 63.50)">14</text>
 </g>
 </svg>

--- a/kanji/07dd1-Kaisho.svg
+++ b/kanji/07dd1-Kaisho.svg
@@ -75,5 +75,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 43.50 52.50)">11</text>
 	<text transform="matrix(1 0 0 1 44.50 77.50)">12</text>
 	<text transform="matrix(1 0 0 1 78.50 50.50)">13</text>
+	<text transform="matrix(1 0 0 1 82.50 71.50)">14</text>
 </g>
 </svg>

--- a/kanji/07dd2-Kaisho.svg
+++ b/kanji/07dd2-Kaisho.svg
@@ -77,5 +77,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 51.50 79.63)">11</text>
 	<text transform="matrix(1 0 0 1 71.50 56.50)">12</text>
 	<text transform="matrix(1 0 0 1 64.67 72.05)">13</text>
+	<text transform="matrix(1 0 0 1 64.50 88.50)">14</text>
 </g>
 </svg>

--- a/kanji/07dd8-Kaisho.svg
+++ b/kanji/07dd8-Kaisho.svg
@@ -99,5 +99,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 58.25 73.25)">12</text>
 	<text transform="matrix(1 0 0 1 58.25 13.25)">13</text>
 	<text transform="matrix(1 0 0 1 79.25 41.25)">14</text>
+	<text transform="matrix(1 0 0 1 74.25 10.25)">15</text>
 </g>
 </svg>

--- a/kanji/07dda-Kaisho.svg
+++ b/kanji/07dda-Kaisho.svg
@@ -81,5 +81,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 56.50 58.63)">12</text>
 	<text transform="matrix(1 0 0 1 43.50 64.50)">13</text>
 	<text transform="matrix(1 0 0 1 87.50 54.13)">14</text>
+	<text transform="matrix(1 0 0 1 70.50 81.50)">15</text>
 </g>
 </svg>

--- a/kanji/07ddd-Kaisho.svg
+++ b/kanji/07ddd-Kaisho.svg
@@ -77,5 +77,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 60.25 50.25)">12</text>
 	<text transform="matrix(1 0 0 1 60.25 63.25)">13</text>
 	<text transform="matrix(1 0 0 1 44.50 80.25)">14</text>
+	<text transform="matrix(1 0 0 1 72.25 48.25)">15</text>
 </g>
 </svg>

--- a/kanji/07ddd-KaishoVt3.svg
+++ b/kanji/07ddd-KaishoVt3.svg
@@ -77,5 +77,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 73.25 47.25)">12</text>
 	<text transform="matrix(1 0 0 1 60.25 50.25)">13</text>
 	<text transform="matrix(1 0 0 1 60.25 63.25)">14</text>
+	<text transform="matrix(1 0 0 1 72.25 48.25)">15</text>
 </g>
 </svg>

--- a/kanji/07dde-Kaisho.svg
+++ b/kanji/07dde-Kaisho.svg
@@ -83,5 +83,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 59.25 30.25)">12</text>
 	<text transform="matrix(1 0 0 1 67.25 17.25)">13</text>
 	<text transform="matrix(1 0 0 1 66.25 52.25)">14</text>
+	<text transform="matrix(1 0 0 1 63.25 72.83)">15</text>
 </g>
 </svg>

--- a/kanji/07de1-Kaisho.svg
+++ b/kanji/07de1-Kaisho.svg
@@ -79,5 +79,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 42.25 73.25)">12</text>
 	<text transform="matrix(1 0 0 1 56.25 62.98)">13</text>
 	<text transform="matrix(1 0 0 1 58.25 76.25)">14</text>
+	<text transform="matrix(1 0 0 1 58.25 91.25)">15</text>
 </g>
 </svg>

--- a/kanji/07de4-Kaisho.svg
+++ b/kanji/07de4-Kaisho.svg
@@ -83,5 +83,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 44.25 63.25)">12</text>
 	<text transform="matrix(1 0 0 1 58.25 57.25)">13</text>
 	<text transform="matrix(1 0 0 1 50.00 76.40)">14</text>
+	<text transform="matrix(1 0 0 1 78.25 73.25)">15</text>
 </g>
 </svg>

--- a/kanji/07de8-Kaisho.svg
+++ b/kanji/07de8-Kaisho.svg
@@ -87,5 +87,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 56.50 53.50)">12</text>
 	<text transform="matrix(1 0 0 1 56.50 70.50)">13</text>
 	<text transform="matrix(1 0 0 1 57.50 63.13)">14</text>
+	<text transform="matrix(1 0 0 1 70.50 62.50)">15</text>
 </g>
 </svg>

--- a/kanji/07dec-Kaisho.svg
+++ b/kanji/07dec-Kaisho.svg
@@ -73,5 +73,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 81.50 47.50)">12</text>
 	<text transform="matrix(1 0 0 1 65.50 53.50)">13</text>
 	<text transform="matrix(1 0 0 1 65.35 69.15)">14</text>
+	<text transform="matrix(1 0 0 1 52.25 88.33)">15</text>
 </g>
 </svg>

--- a/kanji/07df2-Kaisho.svg
+++ b/kanji/07df2-Kaisho.svg
@@ -81,5 +81,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 71.25 10.25)">12</text>
 	<text transform="matrix(1 0 0 1 67.50 25.25)">13</text>
 	<text transform="matrix(1 0 0 1 85.25 24.25)">14</text>
+	<text transform="matrix(1 0 0 1 85.25 47.25)">15</text>
 </g>
 </svg>

--- a/kanji/07df4-Kaisho.svg
+++ b/kanji/07df4-Kaisho.svg
@@ -77,5 +77,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 53.50 59.50)">11</text>
 	<text transform="matrix(1 0 0 1 53.50 12.50)">12</text>
 	<text transform="matrix(1 0 0 1 49.50 73.63)">13</text>
+	<text transform="matrix(1 0 0 1 81.50 72.50)">14</text>
 </g>
 </svg>

--- a/kanji/07e01-Kaisho.svg
+++ b/kanji/07e01-Kaisho.svg
@@ -81,5 +81,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 49.50 64.55)">12</text>
 	<text transform="matrix(1 0 0 1 49.50 79.48)">13</text>
 	<text transform="matrix(1 0 0 1 75.50 48.13)">14</text>
+	<text transform="matrix(1 0 0 1 80.25 69.13)">15</text>
 </g>
 </svg>

--- a/kanji/07e04-Kaisho.svg
+++ b/kanji/07e04-Kaisho.svg
@@ -77,5 +77,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 48.50 50.50)">12</text>
 	<text transform="matrix(1 0 0 1 52.50 62.50)">13</text>
 	<text transform="matrix(1 0 0 1 52.35 75.50)">14</text>
+	<text transform="matrix(1 0 0 1 58.50 23.50)">15</text>
 </g>
 </svg>

--- a/kanji/07e05-Kaisho.svg
+++ b/kanji/07e05-Kaisho.svg
@@ -99,5 +99,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 51.25 57.25)">12</text>
 	<text transform="matrix(1 0 0 1 62.25 14.25)">13</text>
 	<text transform="matrix(1 0 0 1 80.25 40.25)">14</text>
+	<text transform="matrix(1 0 0 1 76.50 9.25)">15</text>
 </g>
 </svg>

--- a/kanji/07e09-Kaisho.svg
+++ b/kanji/07e09-Kaisho.svg
@@ -85,5 +85,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 43.25 70.25)">13</text>
 	<text transform="matrix(1 0 0 1 55.25 61.25)">14</text>
 	<text transform="matrix(1 0 0 1 58.25 75.25)">15</text>
+	<text transform="matrix(1 0 0 1 59.25 90.00)">16</text>
 </g>
 </svg>

--- a/kanji/07e0a-Kaisho.svg
+++ b/kanji/07e0a-Kaisho.svg
@@ -91,5 +91,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 51.75 64.25)">13</text>
 	<text transform="matrix(1 0 0 1 52.25 76.25)">14</text>
 	<text transform="matrix(1 0 0 1 64.25 75.25)">15</text>
+	<text transform="matrix(1 0 0 1 38.25 92.25)">16</text>
 </g>
 </svg>

--- a/kanji/07e0b-Kaisho.svg
+++ b/kanji/07e0b-Kaisho.svg
@@ -81,5 +81,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 42.25 13.25)">13</text>
 	<text transform="matrix(1 0 0 1 41.25 32.25)">14</text>
 	<text transform="matrix(1 0 0 1 41.25 52.25)">15</text>
+	<text transform="matrix(1 0 0 1 32.25 88.25)">16</text>
 </g>
 </svg>

--- a/kanji/07e12-Kaisho.svg
+++ b/kanji/07e12-Kaisho.svg
@@ -83,5 +83,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 46.25 65.25)">13</text>
 	<text transform="matrix(1 0 0 1 61.25 66.25)">14</text>
 	<text transform="matrix(1 0 0 1 63.25 77.25)">15</text>
+	<text transform="matrix(1 0 0 1 51.25 90.00)">16</text>
 </g>
 </svg>

--- a/kanji/07e12-KaishoVtLst.svg
+++ b/kanji/07e12-KaishoVtLst.svg
@@ -83,5 +83,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 46.25 65.25)">13</text>
 	<text transform="matrix(1 0 0 1 61.25 66.25)">14</text>
 	<text transform="matrix(1 0 0 1 63.25 77.25)">15</text>
+	<text transform="matrix(1 0 0 1 51.25 90.00)">16</text>
 </g>
 </svg>

--- a/kanji/07e1b-Kaisho.svg
+++ b/kanji/07e1b-Kaisho.svg
@@ -83,5 +83,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 75.50 10.50)">13</text>
 	<text transform="matrix(1 0 0 1 46.50 67.50)">14</text>
 	<text transform="matrix(1 0 0 1 70.50 63.50)">15</text>
+	<text transform="matrix(1 0 0 1 50.25 85.50)">16</text>
 </g>
 </svg>

--- a/kanji/07e1f-Kaisho.svg
+++ b/kanji/07e1f-Kaisho.svg
@@ -81,5 +81,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 64.25 47.25)">13</text>
 	<text transform="matrix(1 0 0 1 50.25 69.25)">14</text>
 	<text transform="matrix(1 0 0 1 71.25 63.25)">15</text>
+	<text transform="matrix(1 0 0 1 51.50 87.75)">16</text>
 </g>
 </svg>

--- a/kanji/07e21-Kaisho.svg
+++ b/kanji/07e21-Kaisho.svg
@@ -87,5 +87,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 68.25 48.25)">13</text>
 	<text transform="matrix(1 0 0 1 44.25 59.25)">14</text>
 	<text transform="matrix(1 0 0 1 59.25 69.25)">15</text>
+	<text transform="matrix(1 0 0 1 59.25 69.25)">16</text>
 </g>
 </svg>

--- a/kanji/07e26-Kaisho.svg
+++ b/kanji/07e26-Kaisho.svg
@@ -89,5 +89,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 66.50 55.63)">13</text>
 	<text transform="matrix(1 0 0 1 80.25 60.50)">14</text>
 	<text transform="matrix(1 0 0 1 56.50 58.50)">15</text>
+	<text transform="matrix(1 0 0 1 66.50 77.50)">16</text>
 </g>
 </svg>

--- a/kanji/07e31-Kaisho.svg
+++ b/kanji/07e31-Kaisho.svg
@@ -91,5 +91,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 68.25 46.25)">14</text>
 	<text transform="matrix(1 0 0 1 81.25 58.25)">15</text>
 	<text transform="matrix(1 0 0 1 55.25 54.25)">16</text>
+	<text transform="matrix(1 0 0 1 69.25 73.25)">17</text>
 </g>
 </svg>

--- a/kanji/07e32-Kaisho.svg
+++ b/kanji/07e32-Kaisho.svg
@@ -81,5 +81,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 86.25 54.40)">14</text>
 	<text transform="matrix(1 0 0 1 62.25 75.25)">15</text>
 	<text transform="matrix(1 0 0 1 49.25 78.25)">16</text>
+	<text transform="matrix(1 0 0 1 83.00 74.18)">17</text>
 </g>
 </svg>

--- a/kanji/07e35-Kaisho.svg
+++ b/kanji/07e35-Kaisho.svg
@@ -85,5 +85,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 80.25 53.25)">14</text>
 	<text transform="matrix(1 0 0 1 54.25 58.25)">15</text>
 	<text transform="matrix(1 0 0 1 54.25 67.25)">16</text>
+	<text transform="matrix(1 0 0 1 48.25 82.25)">17</text>
 </g>
 </svg>

--- a/kanji/07e37-Kaisho.svg
+++ b/kanji/07e37-Kaisho.svg
@@ -95,5 +95,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 59.25 8.25)">14</text>
 	<text transform="matrix(1 0 0 1 57.25 64.25)">15</text>
 	<text transform="matrix(1 0 0 1 71.25 65.25)">16</text>
+	<text transform="matrix(1 0 0 1 42.25 70.25)">17</text>
 </g>
 </svg>

--- a/kanji/07e3a-Kaisho.svg
+++ b/kanji/07e3a-Kaisho.svg
@@ -81,5 +81,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 40.07 12.25)">14</text>
 	<text transform="matrix(1 0 0 1 40.25 31.33)">15</text>
 	<text transform="matrix(1 0 0 1 41.25 54.25)">16</text>
+	<text transform="matrix(1 0 0 1 30.25 88.25)">17</text>
 </g>
 </svg>

--- a/kanji/07e3d-Kaisho.svg
+++ b/kanji/07e3d-Kaisho.svg
@@ -81,5 +81,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 43.25 72.40)">14</text>
 	<text transform="matrix(1 0 0 1 50.25 87.25)">15</text>
 	<text transform="matrix(1 0 0 1 58.25 72.25)">16</text>
+	<text transform="matrix(1 0 0 1 76.25 70.25)">17</text>
 </g>
 </svg>

--- a/kanji/07e3e-KaishoVtLst.svg
+++ b/kanji/07e3e-KaishoVtLst.svg
@@ -85,5 +85,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 59.50 67.18)">14</text>
 	<text transform="matrix(1 0 0 1 59.50 76.10)">15</text>
 	<text transform="matrix(1 0 0 1 48.50 89.50)">16</text>
+	<text transform="matrix(1 0 0 1 68.50 86.50)">17</text>
 </g>
 </svg>

--- a/kanji/07e43-Kaisho.svg
+++ b/kanji/07e43-Kaisho.svg
@@ -85,5 +85,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 68.25 50.25)">14</text>
 	<text transform="matrix(1 0 0 1 77.25 41.25)">15</text>
 	<text transform="matrix(1 0 0 1 79.25 54.75)">16</text>
+	<text transform="matrix(1 0 0 1 79.25 68.25)">17</text>
 </g>
 </svg>

--- a/kanji/07e46-Kaisho.svg
+++ b/kanji/07e46-Kaisho.svg
@@ -91,5 +91,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 73.25 51.25)">14</text>
 	<text transform="matrix(1 0 0 1 59.25 63.25)">15</text>
 	<text transform="matrix(1 0 0 1 66.25 71.25)">16</text>
+	<text transform="matrix(1 0 0 1 75.25 81.25)">17</text>
 </g>
 </svg>

--- a/kanji/07e4a-Kaisho.svg
+++ b/kanji/07e4a-Kaisho.svg
@@ -93,5 +93,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 36.50 89.50)">14</text>
 	<text transform="matrix(1 0 0 1 59.50 9.50)">15</text>
 	<text transform="matrix(1 0 0 1 79.50 50.50)">16</text>
+	<text transform="matrix(1 0 0 1 75.50 17.50)">17</text>
 </g>
 </svg>

--- a/kanji/07e4d-Kaisho.svg
+++ b/kanji/07e4d-Kaisho.svg
@@ -85,5 +85,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 55.50 74.50)">14</text>
 	<text transform="matrix(1 0 0 1 76.50 74.08)">15</text>
 	<text transform="matrix(1 0 0 1 38.50 48.50)">16</text>
+	<text transform="matrix(1 0 0 1 95.50 47.50)">17</text>
 </g>
 </svg>

--- a/kanji/07e54-Kaisho.svg
+++ b/kanji/07e54-Kaisho.svg
@@ -101,5 +101,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 50.50 82.50)">15</text>
 	<text transform="matrix(1 0 0 1 60.50 14.50)">16</text>
 	<text transform="matrix(1 0 0 1 93.50 54.50)">17</text>
+	<text transform="matrix(1 0 0 1 78.50 18.50)">18</text>
 </g>
 </svg>

--- a/kanji/07e55-Kaisho.svg
+++ b/kanji/07e55-Kaisho.svg
@@ -87,5 +87,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 44.50 66.50)">15</text>
 	<text transform="matrix(1 0 0 1 45.75 86.50)">16</text>
 	<text transform="matrix(1 0 0 1 56.50 76.50)">17</text>
+	<text transform="matrix(1 0 0 1 60.75 91.55)">18</text>
 </g>
 </svg>

--- a/kanji/07e56-Kaisho.svg
+++ b/kanji/07e56-Kaisho.svg
@@ -91,5 +91,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 70.25 14.25)">15</text>
 	<text transform="matrix(1 0 0 1 81.75 33.25)">16</text>
 	<text transform="matrix(1 0 0 1 79.25 45.25)">17</text>
+	<text transform="matrix(1 0 0 1 75.75 54.25)">18</text>
 </g>
 </svg>

--- a/kanji/07e59-Kaisho.svg
+++ b/kanji/07e59-Kaisho.svg
@@ -87,5 +87,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 51.00 66.25)">15</text>
 	<text transform="matrix(1 0 0 1 73.00 75.25)">16</text>
 	<text transform="matrix(1 0 0 1 55.25 78.25)">17</text>
+	<text transform="matrix(1 0 0 1 56.00 92.25)">18</text>
 </g>
 </svg>

--- a/kanji/07e5a-Kaisho.svg
+++ b/kanji/07e5a-Kaisho.svg
@@ -85,5 +85,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 57.25 63.25)">15</text>
 	<text transform="matrix(1 0 0 1 57.25 75.25)">16</text>
 	<text transform="matrix(1 0 0 1 45.25 76.25)">17</text>
+	<text transform="matrix(1 0 0 1 83.25 74.25)">18</text>
 </g>
 </svg>

--- a/kanji/07e5d-Kaisho.svg
+++ b/kanji/07e5d-Kaisho.svg
@@ -89,5 +89,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 52.25 60.25)">15</text>
 	<text transform="matrix(1 0 0 1 65.25 50.75)">16</text>
 	<text transform="matrix(1 0 0 1 66.25 61.25)">17</text>
+	<text transform="matrix(1 0 0 1 66.00 72.25)">18</text>
 </g>
 </svg>

--- a/kanji/07e5e-Kaisho.svg
+++ b/kanji/07e5e-Kaisho.svg
@@ -97,5 +97,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 69.25 57.25)">15</text>
 	<text transform="matrix(1 0 0 1 57.25 68.25)">16</text>
 	<text transform="matrix(1 0 0 1 47.00 82.25)">17</text>
+	<text transform="matrix(1 0 0 1 78.25 80.25)">18</text>
 </g>
 </svg>

--- a/kanji/07e66-Kaisho.svg
+++ b/kanji/07e66-Kaisho.svg
@@ -95,5 +95,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 70.25 61.25)">15</text>
 	<text transform="matrix(1 0 0 1 83.25 41.25)">16</text>
 	<text transform="matrix(1 0 0 1 60.25 87.25)">17</text>
+	<text transform="matrix(1 0 0 1 88.25 74.25)">18</text>
 </g>
 </svg>

--- a/kanji/07e67-Kaisho.svg
+++ b/kanji/07e67-Kaisho.svg
@@ -87,5 +87,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 48.25 58.25)">15</text>
 	<text transform="matrix(1 0 0 1 42.25 71.25)">16</text>
 	<text transform="matrix(1 0 0 1 52.25 83.25)">17</text>
+	<text transform="matrix(1 0 0 1 82.25 81.25)">18</text>
 </g>
 </svg>

--- a/kanji/07e69-Kaisho.svg
+++ b/kanji/07e69-Kaisho.svg
@@ -81,5 +81,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 51.25 79.00)">16</text>
 	<text transform="matrix(1 0 0 1 78.29 43.18)">17</text>
 	<text transform="matrix(1 0 0 1 78.26 59.25)">18</text>
+	<text transform="matrix(1 0 0 1 78.25 77.25)">19</text>
 </g>
 </svg>

--- a/kanji/07e6a-Kaisho.svg
+++ b/kanji/07e6a-Kaisho.svg
@@ -87,5 +87,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 45.25 81.25)">16</text>
 	<text transform="matrix(1 0 0 1 57.25 71.93)">17</text>
 	<text transform="matrix(1 0 0 1 58.26 82.10)">18</text>
+	<text transform="matrix(1 0 0 1 58.25 93.25)">19</text>
 </g>
 </svg>

--- a/kanji/07e70-Kaisho.svg
+++ b/kanji/07e70-Kaisho.svg
@@ -93,5 +93,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 45.00 64.50)">16</text>
 	<text transform="matrix(1 0 0 1 57.75 61.55)">17</text>
 	<text transform="matrix(1 0 0 1 49.50 76.50)">18</text>
+	<text transform="matrix(1 0 0 1 79.50 74.50)">19</text>
 </g>
 </svg>

--- a/kanji/07e79-Kaisho.svg
+++ b/kanji/07e79-Kaisho.svg
@@ -97,5 +97,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 70.25 58.75)">16</text>
 	<text transform="matrix(1 0 0 1 45.25 65.43)">17</text>
 	<text transform="matrix(1 0 0 1 49.25 78.60)">18</text>
+	<text transform="matrix(1 0 0 1 61.25 75.25)">19</text>
 </g>
 </svg>

--- a/kanji/07e7b-Kaisho.svg
+++ b/kanji/07e7b-Kaisho.svg
@@ -93,5 +93,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 40.25 75.25)">17</text>
 	<text transform="matrix(1 0 0 1 46.50 66.25)">18</text>
 	<text transform="matrix(1 0 0 1 52.25 79.03)">19</text>
+	<text transform="matrix(1 0 0 1 66.50 78.25)">20</text>
 </g>
 </svg>

--- a/kanji/07e7d-Kaisho.svg
+++ b/kanji/07e7d-Kaisho.svg
@@ -99,5 +99,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 60.25 71.18)">17</text>
 	<text transform="matrix(1 0 0 1 60.22 80.25)">18</text>
 	<text transform="matrix(1 0 0 1 48.25 93.25)">19</text>
+	<text transform="matrix(1 0 0 1 71.25 93.25)">20</text>
 </g>
 </svg>

--- a/kanji/07e7f-Kaisho.svg
+++ b/kanji/07e7f-Kaisho.svg
@@ -95,5 +95,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 50.00 63.10)">18</text>
 	<text transform="matrix(1 0 0 1 53.00 74.25)">19</text>
 	<text transform="matrix(1 0 0 1 66.00 73.25)">20</text>
+	<text transform="matrix(1 0 0 1 43.25 89.88)">21</text>
 </g>
 </svg>

--- a/kanji/07e7f-KaishoHzFst.svg
+++ b/kanji/07e7f-KaishoHzFst.svg
@@ -95,5 +95,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 50.00 63.10)">18</text>
 	<text transform="matrix(1 0 0 1 53.00 74.25)">19</text>
 	<text transform="matrix(1 0 0 1 66.00 73.25)">20</text>
+	<text transform="matrix(1 0 0 1 43.25 89.88)">21</text>
 </g>
 </svg>

--- a/kanji/07e83-Kaisho.svg
+++ b/kanji/07e83-Kaisho.svg
@@ -91,5 +91,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 41.25 68.25)">17</text>
 	<text transform="matrix(1 0 0 1 56.25 63.25)">18</text>
 	<text transform="matrix(1 0 0 1 56.25 75.50)">19</text>
+	<text transform="matrix(1 0 0 1 75.25 61.25)">20</text>
 </g>
 </svg>

--- a/kanji/07e83-KaishoVt12.svg
+++ b/kanji/07e83-KaishoVt12.svg
@@ -91,5 +91,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 41.25 68.25)">17</text>
 	<text transform="matrix(1 0 0 1 75.25 61.25)">18</text>
 	<text transform="matrix(1 0 0 1 56.25 63.25)">19</text>
+	<text transform="matrix(1 0 0 1 75.25 61.25)">20</text>
 </g>
 </svg>

--- a/kanji/07e88-Kaisho.svg
+++ b/kanji/07e88-Kaisho.svg
@@ -101,5 +101,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 76.22 59.25)">18</text>
 	<text transform="matrix(1 0 0 1 76.21 73.25)">19</text>
 	<text transform="matrix(1 0 0 1 65.25 87.25)">20</text>
+	<text transform="matrix(1 0 0 1 82.25 89.25)">21</text>
 </g>
 </svg>

--- a/kanji/07e89-Kaisho.svg
+++ b/kanji/07e89-Kaisho.svg
@@ -101,5 +101,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 58.26 67.25)">18</text>
 	<text transform="matrix(1 0 0 1 58.25 77.25)">19</text>
 	<text transform="matrix(1 0 0 1 46.25 90.25)">20</text>
+	<text transform="matrix(1 0 0 1 68.25 89.25)">21</text>
 </g>
 </svg>

--- a/kanji/07e8f-Kaisho.svg
+++ b/kanji/07e8f-Kaisho.svg
@@ -103,5 +103,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 73.50 70.50)">18</text>
 	<text transform="matrix(1 0 0 1 47.50 85.78)">19</text>
 	<text transform="matrix(1 0 0 1 65.25 79.20)">20</text>
+	<text transform="matrix(1 0 0 1 48.50 92.50)">21</text>
 </g>
 </svg>

--- a/kanji/07e8f-KaishoVtLst.svg
+++ b/kanji/07e8f-KaishoVtLst.svg
@@ -103,5 +103,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 73.50 70.50)">18</text>
 	<text transform="matrix(1 0 0 1 47.50 85.78)">19</text>
 	<text transform="matrix(1 0 0 1 65.25 79.20)">20</text>
+	<text transform="matrix(1 0 0 1 48.50 92.50)">21</text>
 </g>
 </svg>

--- a/kanji/07e92-Kaisho.svg
+++ b/kanji/07e92-Kaisho.svg
@@ -101,5 +101,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 84.25 67.25)">19</text>
 	<text transform="matrix(1 0 0 1 54.25 79.25)">20</text>
 	<text transform="matrix(1 0 0 1 67.25 76.25)">21</text>
+	<text transform="matrix(1 0 0 1 46.25 91.25)">22</text>
 </g>
 </svg>

--- a/kanji/07e92-KaishoVtLst.svg
+++ b/kanji/07e92-KaishoVtLst.svg
@@ -101,5 +101,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 84.25 67.25)">19</text>
 	<text transform="matrix(1 0 0 1 54.25 79.25)">20</text>
 	<text transform="matrix(1 0 0 1 67.25 76.25)">21</text>
+	<text transform="matrix(1 0 0 1 46.25 91.25)">22</text>
 </g>
 </svg>

--- a/kanji/07e9c-Kaisho.svg
+++ b/kanji/07e9c-Kaisho.svg
@@ -115,5 +115,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 57.25 63.25)">25</text>
 	<text transform="matrix(1 0 0 1 57.13 71.88)">26</text>
 	<text transform="matrix(1 0 0 1 47.25 84.25)">27</text>
+	<text transform="matrix(1 0 0 1 62.25 87.25)">28</text>
 </g>
 </svg>

--- a/kanji/07e9c-KaishoHzFst.svg
+++ b/kanji/07e9c-KaishoHzFst.svg
@@ -115,5 +115,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 57.25 63.25)">25</text>
 	<text transform="matrix(1 0 0 1 57.13 71.88)">26</text>
 	<text transform="matrix(1 0 0 1 47.25 84.25)">27</text>
+	<text transform="matrix(1 0 0 1 62.25 87.25)">28</text>
 </g>
 </svg>

--- a/kanji/07f82-Kaisho.svg
+++ b/kanji/07f82-Kaisho.svg
@@ -87,5 +87,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 49.25 64.25)">15</text>
 	<text transform="matrix(1 0 0 1 62.25 52.25)">16</text>
 	<text transform="matrix(1 0 0 1 63.00 63.18)">17</text>
+	<text transform="matrix(1 0 0 1 63.00 74.25)">18</text>
 </g>
 </svg>

--- a/kanji/07f85-Kaisho.svg
+++ b/kanji/07f85-Kaisho.svg
@@ -87,5 +87,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 77.25 58.23)">16</text>
 	<text transform="matrix(1 0 0 1 59.29 62.25)">17</text>
 	<text transform="matrix(1 0 0 1 59.26 75.25)">18</text>
+	<text transform="matrix(1 0 0 1 59.25 90.25)">19</text>
 </g>
 </svg>

--- a/kanji/0846f-Kaisho.svg
+++ b/kanji/0846f-Kaisho.svg
@@ -77,5 +77,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 33.50 81.50)">9</text>
 	<text transform="matrix(1 0 0 1 54.50 34.50)">10</text>
 	<text transform="matrix(1 0 0 1 70.50 41.50)">11</text>
+	<text transform="matrix(1 0 0 1 63.50 57.50)">12</text>
 </g>
 </svg>

--- a/kanji/0860a-Kaisho.svg
+++ b/kanji/0860a-Kaisho.svg
@@ -95,5 +95,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 53.50 67.50)">16</text>
 	<text transform="matrix(1 0 0 1 57.50 78.50)">17</text>
 	<text transform="matrix(1 0 0 1 68.50 77.35)">18</text>
+	<text transform="matrix(1 0 0 1 45.50 92.50)">19</text>
 </g>
 </svg>

--- a/kanji/08630-Kaisho.svg
+++ b/kanji/08630-Kaisho.svg
@@ -95,5 +95,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 79.50 62.50)">17</text>
 	<text transform="matrix(1 0 0 1 55.50 66.50)">18</text>
 	<text transform="matrix(1 0 0 1 55.50 75.50)">19</text>
+	<text transform="matrix(1 0 0 1 50.50 87.20)">20</text>
 </g>
 </svg>

--- a/kanji/0863f-Kaisho.svg
+++ b/kanji/0863f-Kaisho.svg
@@ -97,5 +97,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 76.50 65.50)">19</text>
 	<text transform="matrix(1 0 0 1 61.27 67.50)">20</text>
 	<text transform="matrix(1 0 0 1 61.50 78.50)">21</text>
+	<text transform="matrix(1 0 0 1 60.09 93.09)">22</text>
 </g>
 </svg>

--- a/kanji/0883b-Kaisho.svg
+++ b/kanji/0883b-Kaisho.svg
@@ -106,5 +106,7 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 33.50 66.50)">21</text>
 	<text transform="matrix(1 0 0 1 36.75 77.50)">22</text>
 	<text transform="matrix(1 0 0 1 44.50 61.50)">23</text>
+	<text transform="matrix(1 0 0 1 16.75 99.50)">24</text>
+	<text transform="matrix(1 0 0 1 77.53 86.24)">25</text>
 </g>
 </svg>

--- a/kanji/08b8a-Kaisho.svg
+++ b/kanji/08b8a-Kaisho.svg
@@ -102,5 +102,7 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 77.50 47.50)">19</text>
 	<text transform="matrix(1 0 0 1 33.50 61.50)">20</text>
 	<text transform="matrix(1 0 0 1 46.50 64.50)">21</text>
+	<text transform="matrix(1 0 0 1 68.19 73.62)">22</text>
+	<text transform="matrix(1 0 0 1 44.42 76.48)">23</text>
 </g>
 </svg>

--- a/kanji/08f61-Kaisho.svg
+++ b/kanji/08f61-Kaisho.svg
@@ -92,5 +92,7 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 70.50 59.50)">18</text>
 	<text transform="matrix(1 0 0 1 78.50 56.50)">19</text>
 	<text transform="matrix(1 0 0 1 23.50 81.50)">20</text>
+	<text transform="matrix(1 0 0 1 37.50 72.50)">21</text>
+	<text transform="matrix(1 0 0 1 39.75 91.50)">22</text>
 </g>
 </svg>

--- a/kanji/0908f-Kaisho.svg
+++ b/kanji/0908f-Kaisho.svg
@@ -99,5 +99,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 8.50 16.50)">20</text>
 	<text transform="matrix(1 0 0 1 5.50 33.50)">21</text>
 	<text transform="matrix(1 0 0 1 0.50 57.13)">22</text>
+	<text transform="matrix(1 0 0 1 2.50 85.50)">23</text>
 </g>
 </svg>

--- a/kanji/0947c-Kaisho.svg
+++ b/kanji/0947c-Kaisho.svg
@@ -107,5 +107,6 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 87.50 57.50)">24</text>
 	<text transform="matrix(1 0 0 1 74.75 60.13)">25</text>
 	<text transform="matrix(1 0 0 1 74.75 73.50)">26</text>
+	<text transform="matrix(1 0 0 1 76.50 88.50)">27</text>
 </g>
 </svg>

--- a/kanji/0947e-Kaisho.svg
+++ b/kanji/0947e-Kaisho.svg
@@ -108,5 +108,7 @@ kvg:type CDATA #IMPLIED >
 	<text transform="matrix(1 0 0 1 24.50 79.13)">23</text>
 	<text transform="matrix(1 0 0 1 43.75 78.13)">24</text>
 	<text transform="matrix(1 0 0 1 25.50 91.50)">25</text>
+	<text transform="matrix(1 0 0 1 61.50 87.50)">26</text>
+	<text transform="matrix(1 0 0 1 11.50 98.50)">27</text>
 </g>
 </svg>


### PR DESCRIPTION
Added the missing stroke numbers in the Kaisho kanji from #441. This was done with a script, however I did visually verify 51 number positions. Some kanji from #441 have already been fixed (see bottom list).

Here's a list showing all the verified kanji:

- 05dd2-Kaisho.svg 
- 05f4e-Kaisho.svg
- 06ade-Kaisho.svg
- 06b12-Kaisho.svg
- 07063-Kaisho.svg
- 07cfa-Kaisho.svg
- 07cfe-Kaisho.svg
- 07d00-Kaisho.svg
- 07d02-Kaisho.svg
- 07d04-Kaisho.svg
- 07d05-Kaisho.svg
- 07d0b-Kaisho.svg
- 07d0d-Kaisho.svg
- 07d10-Kaisho.svg
- 07d14-Kaisho.svg
- 07d15-Kaisho.svg
- 07d17-Kaisho.svg
- 07d18-Kaisho.svg
- 07d19-Kaisho.svg
- 07d1a-Kaisho.svg
- 07d1c-Kaisho.svg
- 07d21-Kaisho.svg
- 07d2c-Kaisho.svg
- 07d30-Kaisho.svg
- 07d32-Kaisho.svg
- 07d33-Kaisho.svg
- 07d35-Kaisho.svg
- 07d39-Kaisho.svg
- 07d3a-Kaisho.svg
- 07d3f-Kaisho.svg
- 07d43-Kaisho.svg
- 07d44-Kaisho.svg
- 07d45-Kaisho.svg
- 07d42-Kaisho.svg
- 07d46-Kaisho.svg
- 07d4b-Kaisho.svg
- 07d4c-Kaisho.svg
- 07d50-Kaisho.svg
- 07d56-Kaisho.svg
- 07d5e-Kaisho.svg
- 07d62-Kaisho.svg
- 07d63-Kaisho.svg
- 07d66-Kaisho.svg
- 07d68-Kaisho.svg
- 07d71-Kaisho.svg
- 07d72-Kaisho.svg
- 07d73-Kaisho.svg
- 07d75-Kaisho.svg
- 07d76-Kaisho.svg
- 07d61-Kaisho.svg
- 07d89-Kaisho.svg

The already fixed kanji from #441 are:

- 07de9-Kaisho.svg
- 07def-Kaisho.svg
- 07e2e-Kaisho.svg
- 07e39-Kaisho.svg
- 07e3e-Kaisho.svg
- 07e8c-Kaisho.svg
- 07e90-Kaisho.svg
- 081e0-Kaisho.svg