### PR TITLE
Fix a stroke type mistaken as element

### DIFF
--- a/kanji/051f8.svg
+++ b/kanji/051f8.svg
@@ -37,7 +37,7 @@ kvg:type CDATA #IMPLIED >
 <svg xmlns="http://www.w3.org/2000/svg" width="109" height="109" viewBox="0 0 109 109">
 <g id="kvg:StrokePaths_051f8" style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;">
 <g id="kvg:051f8" kvg:element="凸">
-	<g id="kvg:051f8-g1" kvg:element="㇐" kvg:radical="nelson">
+	<g id="kvg:051f8-g1" kvg:element="一" kvg:radical="nelson">
 		<path id="kvg:051f8-s1" kvg:type="㇐a" d="M19.44,50.57c2.2-0.13,17.91-1.92,19.92-2.08"/>
 	</g>
 	<path id="kvg:051f8-s2" kvg:type="㇑" d="M39.54,18.19c0.95,0.95,0.98,1.85,0.98,3.49c0,1.2,0.05,15.92,0.08,23.82c0.01,2.91,0.02,4.96,0.02,5.18"/>

--- a/kanji/087ec.svg
+++ b/kanji/087ec.svg
@@ -71,7 +71,7 @@ kvg:type CDATA #IMPLIED >
 				<path id="kvg:087ec-s15" kvg:type="㇐" d="M55.02,49.68c3.04-0.43,30.57-3.46,34.8-3.17"/>
 				<path id="kvg:087ec-s16" kvg:type="㇐" d="M56.54,62.23c10.42-1.43,21.8-2.04,31.42-3.08"/>
 			</g>
-			<g id="kvg:087ec-g11" kvg:element="㇐">
+			<g id="kvg:087ec-g11" kvg:element="一">
 				<path id="kvg:087ec-s17" kvg:type="㇐" d="M48.94,75.38c1.2,0.51,3.41,0.6,4.62,0.51c6.69-0.46,26.02-3.27,41.04-3.97c2.01-0.09,3.21,0.25,4.22,0.5"/>
 			</g>
 			<g id="kvg:087ec-g12" kvg:element="丨">


### PR DESCRIPTION
The horizontal stroke ㇐ (U+31D0) was mistaken as the element 一 (U+4E00) in a couple of places. The former is used to denote stroke types on <path>. But in these two cases it was used to denote elements on <g>.