### PR TITLE
Fix radical of 営

### DIFF
--- a/kanji/055b6.svg
+++ b/kanji/055b6.svg
@@ -38,7 +38,7 @@ kvg:type CDATA #IMPLIED >
 <g id="kvg:StrokePaths_055b6" style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;">
 <g id="kvg:055b6" kvg:element="営">
 	<g id="kvg:055b6-g1" kvg:position="top" kvg:phon="𤇾V">
-		<g id="kvg:055b6-g2" kvg:element="⺍" kvg:original="つ" kvg:radical="tradit">
+		<g id="kvg:055b6-g2" kvg:element="⺍" kvg:original="つ">
 			<path id="kvg:055b6-s1" kvg:type="㇔" d="M26.12,17.25c3.67,3.85,6.5,8.75,7.89,12.25"/>
 			<path id="kvg:055b6-s2" kvg:type="㇔" d="M46.38,13.5c2.18,2.44,6.31,7.38,8.27,12.25"/>
 			<path id="kvg:055b6-s3" kvg:type="㇒" d="M78.64,12.5c0.3,0.9,0.09,2.03-0.43,2.94C77,17.5,73.25,22.75,69.67,26.5"/>
@@ -58,7 +58,7 @@ kvg:type CDATA #IMPLIED >
 			<g id="kvg:055b6-g7" kvg:element="丿">
 				<path id="kvg:055b6-s9" kvg:type="㇒" d="M51.57,65.78c0.3,1.1,0.22,1.75-0.23,2.71c-0.45,0.96-4.29,5.73-5.1,7.01"/>
 			</g>
-			<g id="kvg:055b6-g8" kvg:element="口" kvg:radical="nelson">
+			<g id="kvg:055b6-g8" kvg:element="口" kvg:radical="general">
 				<path id="kvg:055b6-s10" kvg:type="㇑" d="M29.59,76.71c0.48,0.38,1.22,1.45,1.43,1.92c1.43,3.18,2.53,10.1,3.53,16.14c0.15,0.93,0.31,1.85,0.45,2.72"/>
 				<path id="kvg:055b6-s11" kvg:type="㇕b" d="M32.57,78.31c12.05-1.58,33.45-3.53,40.93-3.96c2.61-0.15,4.67,1.73,3.46,4.6c-1.96,4.68-2.48,6.32-4.88,13.73"/>
 				<path id="kvg:055b6-s12" kvg:type="㇐b" d="M35.98,95.48c6.12-0.27,23.61-1.11,34.27-1.5c1.74-0.06,3.28-0.11,4.54-0.15"/>


### PR DESCRIPTION
Dictionaries agree it has radical no. 30 口 but here it is marked as ⺍ with original つ which is not a radical.

See #496