### PR TITLE
Fix `kvg:position` attribute for stroke element `kvg:081ba-Kaisho-g3`

### DIFF
--- a/kanji/081ba-Kaisho.svg
+++ b/kanji/081ba-Kaisho.svg
@@ -43,7 +43,7 @@ kvg:type CDATA #IMPLIED >
 		<path id="kvg:081ba-Kaisho-s3" kvg:type="㇒" d="M26.91,23.58c0.05,1.6,0.1,4.14-0.1,6.45c-1.18,13.59-3.85,46.55-16.58,61.19"/>
 	</g>
 	<g id="kvg:081ba-Kaisho-g2" kvg:position="tarec">
-		<g id="kvg:081ba-Kaisho-g3" kvg:element="倠" kvg:position="倠">
+		<g id="kvg:081ba-Kaisho-g3" kvg:element="倠" kvg:position="top">
 			<g id="kvg:081ba-Kaisho-g4" kvg:element="亻" kvg:variant="true" kvg:original="人">
 				<path id="kvg:081ba-Kaisho-s4" kvg:type="㇒" d="M44.25,26.56c0.1,0.52,0.17,1.18-0.09,1.83c-1.61,4.08-7.35,11.47-14.87,17"/>
 				<path id="kvg:081ba-Kaisho-s5" kvg:type="㇑" d="M39.33,35.82c0.92,0.27,2.12,1.49,2.12,2.05c0,5.81-0.46,14.26-0.46,18.16"/>


### PR DESCRIPTION
Compare to the corresponding stroke element in the non-variant file `081ba.svg`

https://github.com/KanjiVG/kanjivg/blob/b55e0c29aaab02c18cd7d816532d2099b43c889f/kanji/081ba.svg#L46

https://github.com/KanjiVG/kanjivg/blob/b55e0c29aaab02c18cd7d816532d2099b43c889f/kanji/081ba-Kaisho.svg#L46