### PR TITLE
Add a generator for the components database KRADFILE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *~
 kanjivg.xml
+kradfile.txt
 *.pyc
 kanjivg-*xml.gz
 kanjivg-*.zip

--- a/kvg_kradfile.py
+++ b/kvg_kradfile.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+#  -*- coding: utf-8 -*-
+
+from utils import readXmlFile, listSvgFiles
+from kanjivg import StrokeGr
+
+def flatlist(iterable_of_lists):
+	return sum(iterable_of_lists, [])
+
+def subcomponents(strokes):
+	return [
+		component
+		for component in flatlist(
+			[ grp.element ] + subcomponents(grp)
+			for grp in strokes.childs
+			if isinstance(grp, StrokeGr)
+		)
+		if component is not None
+	]
+
+def kanji_component_dic(kanjiVGs):
+	kcdic = {}
+
+	for kanjiVG in kanjiVGs:
+		components = set(subcomponents(kanjiVG.strokes))
+
+		# We want the kanji as its own component if it is a radical
+		if kanjiVG.strokes.radical == "general":
+			components |= { kanjiVG.strokes.element }
+
+		# Add components of all variants of the kanji into its entry
+		if len(components) > 0:
+			kanji = kanjiVG.strokes.element
+			kcdic[kanji] = kcdic.get(kanji, set()) | components
+
+	return kcdic
+
+def kradfile(kanjiVGs):
+	return (
+		kanji + " : " + ' '.join(sorted(components))
+		for kanji, components in kanji_component_dic(kanjiVGs).items()
+	)
+
+if __name__ == "__main__":
+	# Pick your source. The XML doesn't have the variants.
+	#kanjiVGs = readXmlFile('./kanjivg.xml').values()
+	kanjiVGs = [ f.read() for f in listSvgFiles("./kanji/") ]
+
+	with open("./kradfile.txt", mode="w") as output_file:
+		for line in kradfile(kanjiVGs):
+			output_file.write(line+"\n")


### PR DESCRIPTION
Rationale: the KanjiVG project has all the data needed to re-make the venerable KRADFILE project. It is actually a superset in its character coverage.

This `kvg_kradfile.py` script generates the same format, for compatibility with all projects that get kradfile.gz from [http://ftp.edrdg.org/pub/Nihongo/](http://ftp.edrdg.org/pub/Nihongo/). The output of this script is a drop-in replacement.

The original KRADFILE has a few problems: it uses substitutes for many components, such as 化 instead of 亻, 艾 instead of 艹 because those were not available. It's also missing some subcomponents as a result. Generating a kradfile.txt from KanjiVG fixes this.

P.S.: comparisons with the output of the KRADFILE project revealed the need for fixes of omissions in the SVG files, that will follow in another PR.