### PR TITLE
Add 橅 (06a45.svg)

### DIFF
--- a/kanji/06a45.svg
+++ b/kanji/06a45.svg
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (C) 2009/2010/2011 Ulrich Apel.
+This work is distributed under the conditions of the Creative Commons
+Attribution-Share Alike 3.0 Licence. This means you are free:
+* to Share - to copy, distribute and transmit the work
+* to Remix - to adapt the work
+
+Under the following conditions:
+* Attribution. You must attribute the work by stating your use of KanjiVG in
+  your own copyright header and linking to KanjiVG's website
+  (http://kanjivg.tagaini.net)
+* Share Alike. If you alter, transform, or build upon this work, you may
+  distribute the resulting work only under the same or similar license to this
+  one.
+
+See http://creativecommons.org/licenses/by-sa/3.0/ for more details.
+-->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.0//EN" "http://www.w3.org/TR/2001/REC-SVG-20010904/DTD/svg10.dtd" [
+<!ATTLIST g
+xmlns:kvg CDATA #FIXED "http://kanjivg.tagaini.net"
+kvg:element CDATA #IMPLIED
+kvg:variant CDATA #IMPLIED
+kvg:partial CDATA #IMPLIED
+kvg:original CDATA #IMPLIED
+kvg:part CDATA #IMPLIED
+kvg:number CDATA #IMPLIED
+kvg:tradForm CDATA #IMPLIED
+kvg:radicalForm CDATA #IMPLIED
+kvg:position CDATA #IMPLIED
+kvg:radical CDATA #IMPLIED
+kvg:phon CDATA #IMPLIED >
+<!ATTLIST path
+xmlns:kvg CDATA #FIXED "http://kanjivg.tagaini.net"
+kvg:type CDATA #IMPLIED >
+]>
+<svg xmlns="http://www.w3.org/2000/svg" width="109" height="109" viewBox="0 0 109 109">
+<g id="kvg:StrokePaths_06a45" style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;">
+<g id="kvg:06a45" kvg:element="機">
+	<g id="kvg:06a45-g1" kvg:element="木" kvg:position="left" kvg:radical="general">
+		<path id="kvg:06a45-s1" kvg:type="㇐" d="M10.28,39.47c1.6,0.66,3.76,0.28,4.98,0.09c4.46-0.7,12.85-2.31,18.53-3.4c1.23-0.23,2.99-0.8,4.23-0.29"/>
+		<path id="kvg:06a45-s2" kvg:type="㇑" d="M25.36,15c1.26,1.26,1.79,2.75,1.79,4.42c0,0.82-0.04,50.17-0.05,69.95c0,3.14,0,5.54,0,6.88"/>
+		<path id="kvg:06a45-s3" kvg:type="㇒" d="M26.19,39.53c0,0.84-0.1,1.58-0.34,2.33C22,54.25,19.33,62.31,12.11,75.34"/>
+		<path id="kvg:06a45-s4" kvg:type="㇔/㇏" d="M29.88,45.75c2.33,1.62,6.16,6.86,8.12,10"/>
+	</g>
+	<g id="kvg:06a45-g2" kvg:element="無" kvg:position="right">
+		<g id="kvg:06a45-g3" kvg:position="top">
+			<g id="kvg:06a45-g4" kvg:element="丿">
+				<path id="kvg:06a45-s5" kvg:type="㇒" d="M54.51,12.5c0.04,0.56,0.15,1.62-0.08,2.25c-2.72,7.91-6.75,15.16-13.84,21.54"/>
+			</g>
+			<path id="kvg:06a45-s6" kvg:type="㇐" d="M52.83,25c0.72-0.03,2.13-0.1,3.17-0.21c8.01-0.86,23.7-3.89,29.02-4.4c1.4-0.13,2.24,0.17,2.94,0.35"/>
+			<g id="kvg:06a45-g5" kvg:element="一">
+				<path id="kvg:06a45-s7" kvg:type="㇐" d="M37.25,48.7c1.24,0.54,3.52,0.7,4.77,0.54C52,48,80.69,45.25,94.15,44.51c2.07-0.11,3.32,0.26,4.35,0.53"/>
+			</g>
+			<path id="kvg:06a45-s8" kvg:type="㇑" d="M47.09,37.25c0.89,0.5,1.43,2.25,1.6,3.25c0.18,1,0.31,15.75,0.48,27.5"/>
+			<path id="kvg:06a45-s9" kvg:type="㇑" d="M58.37,30.75c0.89,0.5,1.62,2.23,1.6,3.25c-0.07,5.5,0.14,19.5,0.14,33.75"/>
+			<path id="kvg:06a45-s10" kvg:type="㇑" d="M71.65,29.75c0.89,0.5,1.67,2.23,1.6,3.25c-0.47,8-0.88,17.5-1.5,33.25"/>
+			<path id="kvg:06a45-s11" kvg:type="㇑" d="M85.34,30.25c0.89,0.5,1.87,2.28,1.6,4.25c-1.09,8-1.5,15.25-3.54,30.75"/>
+			<path id="kvg:06a45-s12" kvg:type="㇐" d="M37.16,68.7c1.32,0.54,3.74,0.67,5.05,0.54c7.53-0.74,37.49-2.99,51.76-3.73c2.19-0.11,3.52,0.26,4.61,0.53"/>
+		</g>
+		<g id="kvg:06a45-g6" kvg:element="灬" kvg:variant="true" kvg:original="火" kvg:position="bottom">
+			<path id="kvg:06a45-s13" kvg:type="㇔" d="M40.94,80.5c0,5.25-4.71,13-5.94,14.5"/>
+			<path id="kvg:06a45-s14" kvg:type="㇔" d="M53.75,79.08c2.49,2.57,4.85,9.64,5.47,13.63"/>
+			<path id="kvg:06a45-s15" kvg:type="㇔" d="M71.51,78.83c2.4,2.27,6.19,9.35,6.79,12.88"/>
+			<path id="kvg:06a45-s16" kvg:type="㇔" d="M87.89,77.08c3.73,2.89,9.63,11.89,10.56,16.38"/>
+		</g>
+	</g>
+</g>
+</g>
+<g id="kvg:StrokeNumbers_06a45" style="font-size:8;fill:#808080">
+	<text transform="matrix(1 0 0 1 4.99 40.63)">1</text>
+	<text transform="matrix(1 0 0 1 17.50 14.50)">2</text>
+	<text transform="matrix(1 0 0 1 15.49 50.98)">3</text>
+	<text transform="matrix(1 0 0 1 29.50 45.00)">4</text>
+	<text transform="matrix(1 0 0 1 45.50 12.50)">5</text>
+	<text transform="matrix(1 0 0 1 58.50 21.50)">6</text>
+	<text transform="matrix(1 0 0 1 35.50 45.50)">7</text>
+	<text transform="matrix(1 0 0 1 41.50 42.50)">8</text>
+	<text transform="matrix(1 0 0 1 51.50 34.10)">9</text>
+	<text transform="matrix(1 0 0 1 63.50 32.50)">10</text>
+	<text transform="matrix(1 0 0 1 76.25 31.50)">11</text>
+	<text transform="matrix(1 0 0 1 34.50 65.50)">12</text>
+	<text transform="matrix(1 0 0 1 30.50 82.50)">13</text>
+	<text transform="matrix(1 0 0 1 45.50 85.50)">14</text>
+	<text transform="matrix(1 0 0 1 62.50 82.50)">15</text>
+	<text transform="matrix(1 0 0 1 78.50 79.50)">16</text>
+</g>
+</svg>


### PR DESCRIPTION
I fused the 木 from 機 (06a5f.svg) and 無 from 嘸 (05638.svg)

IDs renamed to point to the correct codepoint, stroke IDs and numbers adjusted to reference the correct number. Couldn't find stroke orders online so I assumed they're the same

Also adjusted slightly stroke 4's number position to not overlap with stroke 7's number snapped to a 0.25 grid as that seems to be the general case for the other numbers.