### PR TITLE
Update 060a0.svg (悠)

### DIFF
--- a/kanji/060a0.svg
+++ b/kanji/060a0.svg
@@ -49,7 +49,7 @@ kvg:type CDATA #IMPLIED >
 			<g id="kvg:060a0-g5" kvg:element="攵" kvg:variant="true" kvg:original="攴">
 				<g id="kvg:060a0-g6" kvg:element="𠂉" kvg:position="top">
 					<path id="kvg:060a0-s4" kvg:type="㇒" d="M66.35,10.89c0.04,0.58-0.03,1.79-0.32,2.59c-1.89,5.13-6.5,15.76-13.03,22.85"/>
-					<path id="kvg:060a0-s5" kvg:type="㇐" d="M65.22,22.86c-0.08,0.29,4.31,0.14,4.14,0.16c4.74-0.48,8.51-1.68,15.4-2.28c1.43-0.12,3.21-0.49,4.63-0.13"/>
+					<path id="kvg:060a0-s5" kvg:type="㇐" d="M65.22,22.86c0.08,0.29,4.00,0.14,4.14,0.16c4.74-0.48,8.51-1.68,15.4-2.28c1.43-0.12,3.21-0.49,4.63-0.13"/>
 				</g>
 				<g id="kvg:060a0-g7" kvg:element="乂" kvg:position="bottom">
 					<g id="kvg:060a0-g8" kvg:element="丿">


### PR DESCRIPTION
The first curve of the fifth stroke of the kanji 悠 curves back in on itself near the end points, like this (exaggerated to show the issue)

<img width="749" height="160" alt="2026-07-01 22_44_34-NVIDIA GeForce Overlay DT" src="https://github.com/user-attachments/assets/6fc724e4-0ef9-4056-ab47-1291e1ab50cc" />

The loops are so tiny that on most renderers, this is unnoticeable. However, it does cause issues on some renderers. For example, in Maui's GraphicView, rendering this using `CurveTo` results in a stroke that looks like this

<img width="117" height="47" alt="2026-07-01 22_45_14-Android Emulator - pixel_7_-_api_35_5554" src="https://github.com/user-attachments/assets/fcd8ed4b-5c35-4c39-bc04-5aae344c0c29" />

This PR fixes it so that the control points lie between the end points horizontally. On MAUI, the stroke now looks like this:

<img width="125" height="41" alt="2026-07-01 22_48_50-Android Emulator - pixel_7_-_api_35_5554" src="https://github.com/user-attachments/assets/543e21f9-2067-4816-9f52-e531b912ee21" />

